### PR TITLE
Headline anchor tags for sections in the docs

### DIFF
--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -1,7 +1,34 @@
 const syntaxHighlight = require('@11ty/eleventy-plugin-syntaxhighlight')
 const yaml = require('js-yaml')
+const markdownIt = require('markdown-it')
+const markdownItAnchor = require('markdown-it-anchor')
 
 module.exports = function config(eleventyConfig) {
+  // Render headline anchors in the most accessible way, according to Amber Wilson: https://amberwilson.co.uk/blog/are-your-anchor-links-accessible/#accessibility-check
+  const linkAfterHeader = markdownItAnchor.permalink.linkAfterHeader({
+    style: 'visually-hidden',
+      assistiveText: title => `Section titled "${title}"`,
+      visuallyHiddenClass: 'sr-only',
+      symbol: '🔗'
+  })
+  const markdownItAnchorSettings = {
+    level: [2],
+    permalink (slug, opts, state, idx) {
+      // this is necessary to wrap the headings in an element
+      state.tokens.splice(idx, 0, Object.assign(new state.Token('div_open', 'div', 1), {
+        attrs: [['class', 'heading-wrapper']],
+        block: true
+      }))
+  
+      state.tokens.splice(idx + 4, 0, Object.assign(new state.Token('div_close', 'div', -1), {
+        block: true
+      }))
+      linkAfterHeader(slug, opts, state, idx +1)
+    }
+  }
+  const markdownConfigured = markdownIt({ html: true }).use(markdownItAnchor, markdownItAnchorSettings)
+
+  eleventyConfig.setLibrary('md', markdownConfigured)
   eleventyConfig.addPassthroughCopy('public')
   eleventyConfig.addPassthroughCopy('styles')
   eleventyConfig.addDataExtension('yaml', (contents) => yaml.load(contents))

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -12,6 +12,7 @@
         "@11ty/eleventy": "^1.0.0-canary.41",
         "@11ty/eleventy-plugin-syntaxhighlight": "^3.1.2",
         "js-yaml": "^3.14.1",
+        "markdown-it-anchor": "^8.3.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "sass": "^1.42.1",
@@ -220,6 +221,32 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
+      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.1.tgz",
+      "integrity": "sha512-iij+ilRX/vxtUPCREjn74xzHo/RorHJDwOsJ6X+TgKw7zSvazhVXnDfwlTnyLOMdiVUjtRYU4CrcUZ7Aci4PmQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*",
+        "highlight.js": "^10.7.2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
+      "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
@@ -1710,6 +1737,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/html-dom-parser": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-1.0.1.tgz",
@@ -2421,6 +2458,16 @@
       },
       "bin": {
         "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/markdown-it-anchor": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.3.1.tgz",
+      "integrity": "sha512-i12nPHfLM5uKQXVkzyJt5tZ7DetcYqZoCeiUc9OPqhAhqAR6SOswqMgzqEvDyT5BK6DOc8MmV78VjzCsYM5J5g==",
+      "dev": true,
+      "peerDependencies": {
+        "@types/markdown-it": "*",
+        "markdown-it": "*"
       }
     },
     "node_modules/markdown-it/node_modules/argparse": {
@@ -4519,6 +4566,32 @@
         }
       }
     },
+    "@types/linkify-it": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
+      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+      "dev": true,
+      "peer": true
+    },
+    "@types/markdown-it": {
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.1.tgz",
+      "integrity": "sha512-iij+ilRX/vxtUPCREjn74xzHo/RorHJDwOsJ6X+TgKw7zSvazhVXnDfwlTnyLOMdiVUjtRYU4CrcUZ7Aci4PmQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*",
+        "highlight.js": "^10.7.2"
+      }
+    },
+    "@types/mdurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
+      "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
+      "dev": true,
+      "peer": true
+    },
     "@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -5708,6 +5781,13 @@
       "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
       "dev": true
     },
+    "highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "dev": true,
+      "peer": true
+    },
     "html-dom-parser": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-1.0.1.tgz",
@@ -6278,6 +6358,13 @@
           "dev": true
         }
       }
+    },
+    "markdown-it-anchor": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.3.1.tgz",
+      "integrity": "sha512-i12nPHfLM5uKQXVkzyJt5tZ7DetcYqZoCeiUc9OPqhAhqAR6SOswqMgzqEvDyT5BK6DOc8MmV78VjzCsYM5J5g==",
+      "dev": true,
+      "requires": {}
     },
     "maximatch": {
       "version": "0.1.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,6 +15,7 @@
     "@11ty/eleventy": "^1.0.0-canary.41",
     "@11ty/eleventy-plugin-syntaxhighlight": "^3.1.2",
     "js-yaml": "^3.14.1",
+    "markdown-it-anchor": "^8.3.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "sass": "^1.42.1",

--- a/docs/styles/docs.scss
+++ b/docs/styles/docs.scss
@@ -43,3 +43,17 @@
     padding: 0;
   }
 }
+
+.heading-wrapper {
+  display: flex;
+  gap: 1em;
+  align-items: center;
+
+  &:is(:hover, :focus-within) .header-anchor {
+    opacity: 1;
+  }
+
+  .header-anchor {
+    opacity: 0;
+  }
+}

--- a/docs/styles/styles.scss
+++ b/docs/styles/styles.scss
@@ -184,7 +184,9 @@ a,
 a:visited {
   color: var(--primary);
   padding: 2px;
-  transition: background-position-x 0.2s, color 0.2s;
+  transition-property: background-position-x, color, opacity;
+  transition-duration: 0.2s;
+  transition-timing-function: linear;
   background: linear-gradient(
     80deg,
     var(--bg, var(--black)) 33%,
@@ -203,6 +205,18 @@ a:visited {
 
 h2 {
   margin-top: 2.4rem;
+
+  + .header-anchor {
+    font-size: 1.5em;
+    margin-block-start: 2.4rem;
+    margin-block-end: .83em;
+    padding-inline: .25em;
+
+    @supports not (padding-inline: .25em) {
+      padding-inline-start: .25em;
+      padding-inline-end: .25em;
+    }
+  }
 }
 
 .tagline {
@@ -282,5 +296,17 @@ footer {
     font-size: 0.8rem;
     margin: auto;
     max-width: var(--content-max-width);
+  }
+}
+
+.sr-only {
+  &:not(:where(:focus, :active, :focus-within)) {
+    clip: rect(0 0 0 0); 
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap; 
+    width: 1px;
   }
 }

--- a/docs/styles/styles.scss
+++ b/docs/styles/styles.scss
@@ -205,7 +205,7 @@ a:visited {
 
 h2 {
   margin-top: 2.4rem;
-
+scroll-margin-top: 1rem;
   + .header-anchor {
     font-size: 1.5em;
     margin-block-start: 2.4rem;


### PR DESCRIPTION
Closes #38 as described in [this issue](https://github.com/slinkity/slinkity/issues/38):

- adds the `markdown-it-anchor` which allows automatic generation of headline links in an accessible way.
- the plugin is configured in a way that is congruent with [the suggestions of Amber Wilson](https://amberwilson.co.uk/blog/are-your-anchor-links-accessible/#accessibility-check) regarding this issue.
- Links are currently only generated for `<h2>`'s, which can be changed at any time.
- Headline Anchors are transparent until the wrapping element is hovered, or until it receives focus.