### PR TITLE
Sticky & Responsive Docs TOC

### DIFF
--- a/docs/styles/docs.scss
+++ b/docs/styles/docs.scss
@@ -1,20 +1,31 @@
 .docs__container {
   --nav-width: 200px;
+  --site-gap: 40px;
   display: grid;
-  grid-template-columns: var(--nav-width) 1fr;
+  grid-template-columns: 1fr;
   max-width: calc(var(--content-max-width) + var(--nav-width));
   width: 100%;
   align-items: flex-start;
   margin: auto;
   padding: 0 20px;
-  column-gap: 40px;
+  gap: var(--site-gap);
+
+  @media (min-width: $tablet) {
+    grid-template-columns: [side-start] var(--nav-width) [side-end content-start] 1fr [content-end];
+  }
 
   .docs__nav {
     list-style: none;
     padding: 16px 0;
     background: var(--grey-100);
     border-radius: 10px;
-    margin-top: 40px;
+    position: sticky;
+    top: var(--site-gap);
+
+    @media (min-width: $tablet) {
+      margin-block-start: var(--site-gap);
+      grid-column: side-start / side-end;
+    }
 
     li {
       margin: 0;
@@ -41,5 +52,13 @@
     max-width: auto;
     margin: 0;
     padding: 0;
+
+    > h1 {
+      margin-block-start: var(--site-gap);
+    }
+
+    @media (min-width: $tablet) {
+      grid-column: content-start / content-end;
+    }
   }
 }

--- a/docs/styles/styles.scss
+++ b/docs/styles/styles.scss
@@ -1,3 +1,6 @@
+$mobile: 500px;
+$tablet: 860px;
+
 @import './docs.scss';
 @import './home.scss';
 
@@ -36,8 +39,6 @@
   font-style: italic;
   font-display: swap;
 }
-
-$mobile: 500px;
 
 :root {
   --content-max-width: 740px;


### PR DESCRIPTION
resolves #37 

+ new breakpoint variable `$tablet`, for 860px.
+ the docs layout breaks at this min-width into a multi-column layout
+ the toc is now sticky.

I moved the reused `40px` into a new custom property `--site-gap` and called it that way, because that way reused values show how they are connected to this value. Meaning, the `.docs__nav` `top`-value is that way abstractly connected to the `gap` value of the layout, as is the first `<h1>`'s margin-block-start, etc.