### PR TITLE
fix the quick-docs layout

### DIFF
--- a/docs/styles/docs.scss
+++ b/docs/styles/docs.scss
@@ -49,7 +49,8 @@
   }
 
   .docs {
-    max-width: auto;
+    overflow: auto;
+    max-width: 100%;
     margin: 0;
     padding: 0;
 


### PR DESCRIPTION
+ fixes the layout break caused be the overflowing code blocks 
+ fixes another small issue, in where the main part of the docs didn't fill out its available width