### PR TITLE
Fix: Vite entrypoint prebundling

### DIFF
--- a/src/cli/toViteSSR.js
+++ b/src/cli/toViteSSR.js
@@ -47,7 +47,7 @@ function gimmeCSSPlugin() {
  * }} FormattedModule - expected keys from a given component module
  *
  * @typedef ViteSSR - available fns for module conversion
- * @property {(filePath: string) => Promise<FormattedModule>} toComponentCommonJSModule - fn to grab a Node-friendly module output from a given file path
+ * @property {(filePath: string) => Promise<FormattedModule>} toCommonJSModule - fn to grab a Node-friendly module output from a given file path
  * @property {import('vite').ViteDevServer | null} server
  *
  * @returns {ViteSSR} viteSSR
@@ -68,7 +68,7 @@ module.exports = async function toViteSSR({ environment, dir }) {
       },
     })
     return {
-      async toComponentCommonJSModule(filePath) {
+      async toCommonJSModule(filePath) {
         const viteOutput = await server.ssrLoadModule(filePath)
         return {
           default: () => null,
@@ -86,7 +86,7 @@ module.exports = async function toViteSSR({ environment, dir }) {
      */
     const probablyInefficientCache = {}
     return {
-      async toComponentCommonJSModule(filePath) {
+      async toCommonJSModule(filePath) {
         if (probablyInefficientCache[filePath]) return probablyInefficientCache[filePath]
         const { output } = await build({
           ...ssrViteConfig,

--- a/src/cli/vite.js
+++ b/src/cli/vite.js
@@ -38,6 +38,10 @@ async function getSharedConfig(dir) {
     configFile: await getConfigFile(),
     resolve: {
       alias: Object.fromEntries(importAliasesToResolvedPath),
+      dedupe: ['react', 'react-dom'],
+    },
+    optimizeDeps: {
+      include: ['react', 'react/jsx-runtime', 'react/jsx-dev-runtime', 'react-dom'],
     },
   })
 }

--- a/src/plugin/applyViteHtmlTransform.js
+++ b/src/plugin/applyViteHtmlTransform.js
@@ -48,8 +48,9 @@ async function applyViteHtmlTransform(
     ?.insertAdjacentHTML('beforeend', `<style>${Object.values(pageStyles).join('\n')}</style>`)
 
   const routePath = '/' + toSlashesTrimmed(relative(dir.output, outputPath))
-  return environment === 'dev'
-    ? viteSSR.server.transformIndexHtml(routePath, root.outerHTML)
+  const server = viteSSR.getServer()
+  return environment === 'dev' && server
+    ? server.transformIndexHtml(routePath, root.outerHTML)
     : root.outerHTML
 }
 

--- a/src/plugin/applyViteHtmlTransform.js
+++ b/src/plugin/applyViteHtmlTransform.js
@@ -30,7 +30,7 @@ async function applyViteHtmlTransform(
     const componentAttrs = allComponentAttrsForPage[id]
     if (componentAttrs) {
       const { path: componentPath, props, hydrate } = componentAttrs
-      const { default: Component, __stylesGenerated } = await viteSSR.toComponentCommonJSModule(
+      const { default: Component, __stylesGenerated } = await viteSSR.toCommonJSModule(
         componentPath,
       )
       Object.assign(pageStyles, __stylesGenerated)

--- a/src/plugin/reactPlugin/1-pluginDefinitions/addPageExtension.js
+++ b/src/plugin/reactPlugin/1-pluginDefinitions/addPageExtension.js
@@ -14,17 +14,21 @@ module.exports = function addPageExtension(
   eleventyConfig,
   { componentAttrStore, viteSSR, resolvedImportAliases },
 ) {
+  let useCache = false
   eleventyConfig.addExtension('jsx', {
     read: false,
     getData: async (inputPath) => {
       const absInputPath = join(resolvedImportAliases.root, inputPath)
-      const { frontMatter } = await viteSSR.toCommonJSModule(absInputPath)
+      useCache = true
+      const { frontMatter } = await viteSSR.toCommonJSModule(absInputPath, { useCache })
       return frontMatter
     },
     compile: (_, inputPath) =>
       async function (data) {
         const absInputPath = join(resolvedImportAliases.root, inputPath)
-        const { getProps, frontMatter } = await viteSSR.toCommonJSModule(absInputPath)
+        const { getProps, frontMatter } = await viteSSR.toCommonJSModule(absInputPath, {
+          useCache,
+        })
 
         const props = await getProps(
           toFormattedDataForProps({
@@ -43,5 +47,10 @@ module.exports = function addPageExtension(
 
         return toMountPoint({ id, hydrate })
       },
+  })
+
+  eleventyConfig.on('afterBuild', () => {
+    // use caching for the duration of the build, and invalidate when the build is complete
+    useCache = false
   })
 }

--- a/src/plugin/reactPlugin/1-pluginDefinitions/addPageExtension.js
+++ b/src/plugin/reactPlugin/1-pluginDefinitions/addPageExtension.js
@@ -18,13 +18,13 @@ module.exports = function addPageExtension(
     read: false,
     getData: async (inputPath) => {
       const absInputPath = join(resolvedImportAliases.root, inputPath)
-      const { frontMatter } = await viteSSR.toComponentCommonJSModule(absInputPath)
+      const { frontMatter } = await viteSSR.toCommonJSModule(absInputPath)
       return frontMatter
     },
     compile: (_, inputPath) =>
       async function (data) {
         const absInputPath = join(resolvedImportAliases.root, inputPath)
-        const { getProps, frontMatter } = await viteSSR.toComponentCommonJSModule(absInputPath)
+        const { getProps, frontMatter } = await viteSSR.toCommonJSModule(absInputPath)
 
         const props = await getProps(
           toFormattedDataForProps({


### PR DESCRIPTION
Resolves #54 

- **Moves Vite server startup to after your first 11ty build.** This allows Vite to prebundle any dependencies used in your build output
- **Adds React + React dependencies to the prebundling steps.** This mirrors [Astro's React renderer](https://github.com/snowpackjs/astro/blob/main/packages/renderers/renderer-react/index.js) and sets us up for renderer plugins (see #55)
- **Uses Vite's rollup build when processing component page frontmatter** _before_ the Vite server is started. This is the best compromise I could find to delay the dev server while still processing `frontMatter` and `getProps` during 11ty's build process. This does mean an initial performance hit on startup, but we'll use `ssrLoadModule` thereafter