### PR TITLE
Fix: import aliases on production builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "slinkity",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slinkity",
   "description": "To 11ty and beyond! The all-in-one tool for templates where you want them, component frameworks where you need them",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "license": "MIT",
   "main": "./lib/main/index.js",
   "types": "./lib/main/index.d.ts",

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -112,7 +112,7 @@ const userConfigDir = toEleventyConfigDir({
       output: intermediateDir.split(sep).join('/'),
     })(toEleventyOptions(options))
     await viteBuild({
-      ...userConfigDir,
+      eleventyDir: userConfigDir,
       input: intermediateDir,
       output: outputDir,
     })


### PR DESCRIPTION
Resolves #77 

- use user's input directory instead of our temporary build directory when resolving aliases
- move _all_ React prebundling logic inside that try / catch. Noticed another issue when attempting a React-less production build!