### PR TITLE
check for outputPath boolean before applying `endsWith`

### DIFF
--- a/src/plugin/applyViteHtmlTransform.js
+++ b/src/plugin/applyViteHtmlTransform.js
@@ -17,7 +17,7 @@ async function applyViteHtmlTransform(
   { content, outputPath, componentAttrStore },
   { dir, viteSSR, environment },
 ) {
-  if (!outputPath.endsWith('.html')) {
+  if (!outputPath || !outputPath.endsWith('.html')) {
     return content
   }
 

--- a/src/plugin/index.js
+++ b/src/plugin/index.js
@@ -76,7 +76,7 @@ module.exports = function slinkityConfig({ userSlinkityConfig, ...options }) {
     eleventyConfig.addTransform(
       'apply-react-hydration-loaders',
       async function (content, outputPath) {
-        if (!outputPath.endsWith('.html')) return content
+        if (!outputPath || !outputPath.endsWith('.html')) return content
 
         const componentAttrs = componentAttrStore
           .getAllByPage(outputPath)


### PR DESCRIPTION
Eleventy sets `outputPath` to `false` when user sets `permalink: false`. So we should check for it.

As per: https://github.com/11ty/eleventy/issues/653

This PR solves #82 