### PR TITLE
Fix: multiple shortcodes breaks dev server

### DIFF
--- a/src/plugin/reactPlugin/2-pageTransform/__snapshots__/toHydrationLoadersApplied.test.js.snap
+++ b/src/plugin/reactPlugin/2-pageTransform/__snapshots__/toHydrationLoadersApplied.test.js.snap
@@ -26,32 +26,32 @@ exports[`toHydrationLoadersApplied with hydrated components should apply correct
   window.customElements.define(\\"slinkity-react-mount-point\\", MountPoint);
 </script>
 <script type=\\"module\\">
-    import Component from \\"not-important.jsx\\";
-    import eagerLoader from \\"slinkity/lib/plugin/reactPlugin/_client/_eager-loader.js\\";
+    import Component0 from \\"not-important.jsx\\";
+    import eagerLoader0 from \\"slinkity/lib/plugin/reactPlugin/_client/_eager-loader.js\\";
   
-    eagerLoader({ 
+    eagerLoader0({ 
       id: \\"0\\",
-      Component,
+      Component: Component0,
       props: {},
     });
   </script>
 <script type=\\"module\\">
-    import Component from \\"not-important.jsx\\";
-    import eagerLoader from \\"slinkity/lib/plugin/reactPlugin/_client/_eager-loader.js\\";
+    import Component1 from \\"not-important.jsx\\";
+    import eagerLoader1 from \\"slinkity/lib/plugin/reactPlugin/_client/_eager-loader.js\\";
   
-    eagerLoader({ 
+    eagerLoader1({ 
       id: \\"1\\",
-      Component,
+      Component: Component1,
       props: {},
     });
   </script>
 <script type=\\"module\\">
-    import Component from \\"not-important.jsx\\";
-    import eagerLoader from \\"slinkity/lib/plugin/reactPlugin/_client/_eager-loader.js\\";
+    import Component2 from \\"not-important.jsx\\";
+    import eagerLoader2 from \\"slinkity/lib/plugin/reactPlugin/_client/_eager-loader.js\\";
   
-    eagerLoader({ 
+    eagerLoader2({ 
       id: \\"2\\",
-      Component,
+      Component: Component2,
       props: {},
     });
   </script></body>
@@ -84,27 +84,27 @@ exports[`toHydrationLoadersApplied with hydrated components should apply correct
   window.customElements.define(\\"slinkity-react-mount-point\\", MountPoint);
 </script>
 <script type=\\"module\\">
-    import lazyLoader from \\"slinkity/lib/plugin/reactPlugin/_client/_lazy-loader.js\\";
+    import lazyLoader0 from \\"slinkity/lib/plugin/reactPlugin/_client/_lazy-loader.js\\";
   
-    lazyLoader({ 
+    lazyLoader0({ 
       id: \\"0\\",
       componentImporter: async () => await import(\\"not-important.jsx\\"),
       props: {},
     });
   </script>
 <script type=\\"module\\">
-    import lazyLoader from \\"slinkity/lib/plugin/reactPlugin/_client/_lazy-loader.js\\";
+    import lazyLoader1 from \\"slinkity/lib/plugin/reactPlugin/_client/_lazy-loader.js\\";
   
-    lazyLoader({ 
+    lazyLoader1({ 
       id: \\"1\\",
       componentImporter: async () => await import(\\"not-important.jsx\\"),
       props: {},
     });
   </script>
 <script type=\\"module\\">
-    import lazyLoader from \\"slinkity/lib/plugin/reactPlugin/_client/_lazy-loader.js\\";
+    import lazyLoader2 from \\"slinkity/lib/plugin/reactPlugin/_client/_lazy-loader.js\\";
   
-    lazyLoader({ 
+    lazyLoader2({ 
       id: \\"2\\",
       componentImporter: async () => await import(\\"not-important.jsx\\"),
       props: {},
@@ -139,30 +139,30 @@ exports[`toHydrationLoadersApplied with hydrated components should apply correct
   window.customElements.define(\\"slinkity-react-mount-point\\", MountPoint);
 </script>
 <script type=\\"module\\">
-    import Component from \\"nav.jsx\\";
-    import eagerLoader from \\"slinkity/lib/plugin/reactPlugin/_client/_eager-loader.js\\";
+    import Component0 from \\"nav.jsx\\";
+    import eagerLoader0 from \\"slinkity/lib/plugin/reactPlugin/_client/_eager-loader.js\\";
   
-    eagerLoader({ 
+    eagerLoader0({ 
       id: \\"0\\",
-      Component,
+      Component: Component0,
       props: {firstProp:'nice',secondProp:42,thirdProp:false,helper() {
   return 'Testing non-JSON properties';
 }},
     });
   </script>
 <script type=\\"module\\">
-    import lazyLoader from \\"slinkity/lib/plugin/reactPlugin/_client/_lazy-loader.js\\";
+    import lazyLoader1 from \\"slinkity/lib/plugin/reactPlugin/_client/_lazy-loader.js\\";
   
-    lazyLoader({ 
+    lazyLoader1({ 
       id: \\"1\\",
       componentImporter: async () => await import(\\"nested/Heading.jsx\\"),
       props: {text:{weight:'bold',content:'Welcome to the site'}},
     });
   </script>
 <script type=\\"module\\">
-    import lazyLoader from \\"slinkity/lib/plugin/reactPlugin/_client/_lazy-loader.js\\";
+    import lazyLoader2 from \\"slinkity/lib/plugin/reactPlugin/_client/_lazy-loader.js\\";
   
-    lazyLoader({ 
+    lazyLoader2({ 
       id: \\"2\\",
       componentImporter: async () => await import(\\"index.jsx\\"),
       props: {list:['Have a nice day world']},

--- a/src/plugin/reactPlugin/2-pageTransform/toLoaderScript.js
+++ b/src/plugin/reactPlugin/2-pageTransform/toLoaderScript.js
@@ -18,20 +18,20 @@ module.exports = function toLoaderScript({ componentPath, hydrate, id, props = {
   const componentImportStatement = JSON.stringify(toUnixPath(componentPath))
   if (hydrate === 'eager') {
     return `<script type="module">
-    import Component from ${componentImportStatement};
-    import eagerLoader from ${toClientImportStatement('_eager-loader.js')};
+    import Component${id} from ${componentImportStatement};
+    import eagerLoader${id} from ${toClientImportStatement('_eager-loader.js')};
   
-    eagerLoader({ 
+    eagerLoader${id}({ 
       id: "${id}",
-      Component,
+      Component: Component${id},
       props: ${stringify(props)},
     });
   </script>`
   } else if (hydrate === 'lazy') {
     return `<script type="module">
-    import lazyLoader from ${toClientImportStatement('_lazy-loader.js')};
+    import lazyLoader${id} from ${toClientImportStatement('_lazy-loader.js')};
   
-    lazyLoader({ 
+    lazyLoader${id}({ 
       id: "${id}",
       componentImporter: async () => await import(${componentImportStatement}),
       props: ${stringify(props)},


### PR DESCRIPTION
Resolves #85 

## What changed?

We added the component's ID to the default import name. This ensures each import is unique to make ESBuild happy!

Note for the future: this could break if we ever change from a numeric ID system.