### PR TITLE
Docs: rework quick start with new `npm init slinkity`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Slinkity is the simplest way to handle styles and component frameworks on your 1
 - 💧 **Hydrates these components** when and how you want. Use component frameworks as a static template to start, and opt-in to shipping JS as needed with our [partial hydration helpers](/docs/partial-hydration).
 - 💅 **Bundles all your resources** with the power of Vite. Use your favorite CSS preprocessor, JS minifier, and more with minimal config.
 
-### [📣 Find our full announcement post here →](/)
+### [📣 Find our full announcement post here →](https://slinkity.dev)
 
 ## Technologies used
 
@@ -29,7 +29,7 @@ Use our handy CLI command to spin up a Slinkity site: `npm init slinkity`. This 
 
 To learn more, and explore adding Slinkity to _existing_ 11ty projects...
 
-### [🐣 See our "quick start" guide →](/docs/quick-start)
+### [🐣 See our "quick start" guide →](https://slinkity.dev/docs/quick-start)
 
 ## Feature set
 

--- a/README.md
+++ b/README.md
@@ -7,77 +7,54 @@
 
 > 🚧 **This project is heavily under construction!** 🚧 As excited as you may be, we don't recommend this early alpha for production use. Still, give it a try if you want to have some fun and don't mind [logging bugs](https://github.com/slinkity/slinkity/issues) along the way :)
 
-Slinkity is a tool for bringing dynamic, clientside interactions to your static 11ty site. Once installed, this:
+Slinkity is the simplest way to handle styles and component frameworks on your 11ty site. Once installed, this:
 
-- 🚀 **Unlocks component frameworks** (like React) for writing page templates and layout templates. So, you can turn an existing `.html` or `.liquid` file into a `.jsx` file, and immediately start building routes using React.
-- 🔖 **Includes powerful shortcodes** to insert components into existing pages. Add a line like this to your markdown, HTML, Nunjucks, etc, and watch the magic happen: `{% react './path/to/component.jsx' %}`
-- 💧 **Hydrates these component-driven pages** on the client. In other words, all your dynamic state management will work in development and production with 0 extra setup.
+- 🚀 **Unlocks component frameworks** like React for writing page templates and layout templates. Turn an existing `.html` or `.liquid` file into a `.jsx` file, and you're off to the componentized races.
+- 🔖 **Includes powerful shortcodes** to insert components into existing pages. Add a line like this to your markdown, HTML, Nunjucks, etc, and watch the magic happen: {% raw %}`{% react 'path/to/component' %}`{% endraw %}
+- 💧 **Hydrates these components** when and how you want. Use component frameworks as a static template to start, and opt-in to shipping JS as needed with our [partial hydration helpers](/docs/partial-hydration).
+- 💅 **Bundles all your resources** with the power of Vite. Use your favorite CSS preprocessor, JS minifier, and more with minimal config.
 
-### [📣 Find our full announcement post here →](https://slinkity.dev/)
+### [📣 Find our full announcement post here →](/)
 
-## Quick start
+## Technologies used
 
-All you need is an empty directory to get started! But if you prefer a starter project with some pre-populated content, you can use the lovely guide + community resources [over on the 11ty docs](https://www.11ty.dev/docs/getting-started/).
+Slinkity stands on the shoulders of giants. You can think of Slinkity as the "glue" binding 2 tools together:
 
-### Installation
+1. [**Eleventy:**](https://www.11ty.dev) a static site generator with a rich feature set for fetching data, composing layouts, and inserting content with "shortcodes."
+2. [**Vite:**](https://vitejs.dev) a bundler that takes the boilerplate out of your set up. It'll compile JS component frameworks, handle CSS preprocessors with little-to-no config (say, SCSS and PostCSS), and show dev changes on-the-fly using [hot module replacement (HMR)](https://vitejs.dev/guide/features.html#hot-module-replacement).
 
-First, install Slinkity + the latest 11ty into your project repo like so:
+## Getting started
 
-> Slinkity requires Node v14 and up. You can check your version by running `node -v` in your terminal before trying Slinkity.
+Use our handy CLI command to spin up a Slinkity site: `npm init slinkity`. This demos our core functionality while staying as lean as possible, making it the perfect launchpad for new projects 🚀
 
-```bash
-npm i --save-dev slinkity @11ty/eleventy@beta
-```
+To learn more, and explore adding Slinkity to _existing_ 11ty projects...
 
-> Slinkity relies on 11ty's [latest 1.0 beta build](https://www.npmjs.com/package/@11ty/eleventy/v/beta) to work properly. Yes, this could involve some gotchas with existing 11ty plugins! If anything unexpected happens, let us know on our [GitHub issues page](https://github.com/slinkity/slinkity/issues).
-
-...and run our CLI command to spin up the dev server:
-
-```bash
-npx slinkity --serve
-# Also consider the --incremental flag
-# for faster builds during development
-```
-
-Now you're off to the races! This command will:
-
-1. Start up [11ty in `--watch` mode](https://www.11ty.dev/docs/usage/#re-run-eleventy-when-you-save) to listen for file changes
-2. Start up [a Vite server](https://vitejs.dev/guide/#index-html-and-project-root) pointed at your 11ty build. This helps us process all sorts of file types, including SASS styles, React components, and more 🚀
-
-When you're ready for a production build, just run:
-
-```bash
-npx slinkity
-```
-
-...and your shiny new site will appear in the `_site` folder (or [wherever you tell 11ty to build your site](https://www.11ty.dev/docs/config/#output-directory)).
-
-### [📚 Dive in to the docs here →](https://slinkity.dev/docs/quick-start/)
+### [🐣 See our "quick start" guide →](/docs/quick-start)
 
 ## Feature set
 
-This project is still in early alpha, so we have many features soon to come! [This demo](https://twitter.com/BHolmesDev/status/1404427102032740353?s=20) covers a majority of features we plan to support. For reference, here's our tentative roadmap to version 1.0:
+This project is still in early alpha, so we have many features soon to come! [This demo](https://www.youtube.com/watch?v=X_zp6CodHjc&t=493s) covers a majority of features we support today. For reference, here's our complete roadmap of current and upcoming features:
 
-| Feature                                         | Status |
-| ----------------------------------------------- | ------ |
-| CLI to run 11ty and Vite simultaneously         | ✅ | 
-| React component pages & layouts                 | ✅ | 
-| React component shortcodes                      | ✅ |
-| SASS support                                    | ✅ |
-| CSS module support*                             | ⏺ |
-| First-class page transition library             | ⏳ |
-| Single page app capabilities                    | ⏳ |
-| Vue component pages, layouts and shortcodes     | ❌ |
-| Svelte component pages, layouts and shortcodes  | ❌ |
-| Tailwind support                                | ❌ |
-| Styled components & Emotion support             | ❌ |
+| Feature                                                | Status |
+| ------------------------------------------------------ | ------ |
+| CLI to run 11ty and Vite simultaneously                | ✅      |
+| React component pages & layouts                        | ✅      |
+| React component shortcodes                             | ✅      |
+| SCSS and SASS                                          | ✅      |
+| PostCSS config (ex. Tailwind)                          | ✅      |
+| CSS imports via ESM (including CSS modules) *          | ⏺      |
+| Plugin ecosystem for your favorite component framework |
+| (Vue, Svelte, Solid, etc)                              | ⏳      |
+| Eleventy serverless compatibility                      | ❌      |
+| Shared state between component shortcodes              | ❌      |
+| Styled components & Emotion                            | ❌      |
 
-_*CSS modules **will** work with JavaScript enabled. However, disabling JavaScript or rendering your components as "static" will break this behavior._
+_*CSS imports will work today, but with one caveat: stylesheets will bleed to other routes on your site. We're actively working on a fix!_
 
 - ✅ = Ready to use
 - ⏺ = Partial support
 - ⏳ = In progress
-- ❌ = Not started (but on roadmap)
+- ❌ = Not started, but on roadmap
 
 ## Have an idea? Notice a bug?
 

--- a/docs/src/_includes/npm-init-slinkity-snippet.md
+++ b/docs/src/_includes/npm-init-slinkity-snippet.md
@@ -1,0 +1,1 @@
+Use our handy CLI command to spin up a Slinkity site: `npm init slinkity`. This demos our core functionality while staying as lean as possible, making it the perfect launchpad for new projects 🚀

--- a/docs/src/_includes/value-props.md
+++ b/docs/src/_includes/value-props.md
@@ -1,4 +1,4 @@
-Slinkity is the missing piece to handling styles and component frameworks in your 11ty site. Once installed, this:
+Slinkity is the missing piece to handle styles and component frameworks in your 11ty site. Once installed, this:
 
 - 🚀 **Unlocks component frameworks** (like React) for writing page templates and layout templates. So, you can turn an existing `.html` or `.liquid` file into a `.jsx` file, and immediately start building routes using React.
 - 🔖 **Includes powerful shortcodes** to insert components into existing pages. Add a line like this to your markdown, HTML, Nunjucks, etc, and watch the magic happen: {% raw %}`{% react './path/to/component.jsx' %}`{% endraw %}

--- a/docs/src/_includes/value-props.md
+++ b/docs/src/_includes/value-props.md
@@ -1,0 +1,6 @@
+Slinkity is the missing piece to handling styles and component frameworks in your 11ty site. Once installed, this:
+
+- 🚀 **Unlocks component frameworks** (like React) for writing page templates and layout templates. So, you can turn an existing `.html` or `.liquid` file into a `.jsx` file, and immediately start building routes using React.
+- 🔖 **Includes powerful shortcodes** to insert components into existing pages. Add a line like this to your markdown, HTML, Nunjucks, etc, and watch the magic happen: {% raw %}`{% react './path/to/component.jsx' %}`{% endraw %}
+- 💧 **Hydrates these components** when and how you want. Use component frameworks as a static template to start, and opt-in to shipping JS as needed with our [partial hydration helpers](/docs/partial-hydration).
+- 💅 **Bundles all your resources** with the power of Vite. Use your favorite CSS preprocessor, JS minifier, and more with the least config possible.

--- a/docs/src/_includes/value-props.md
+++ b/docs/src/_includes/value-props.md
@@ -1,6 +1,6 @@
-Slinkity is the missing piece to handle styles and component frameworks in your 11ty site. Once installed, this:
+Slinkity is the simplest way to handle styles and component frameworks on your 11ty site. Once installed, this:
 
-- 🚀 **Unlocks component frameworks** (like React) for writing page templates and layout templates. So, you can turn an existing `.html` or `.liquid` file into a `.jsx` file, and immediately start building routes using React.
-- 🔖 **Includes powerful shortcodes** to insert components into existing pages. Add a line like this to your markdown, HTML, Nunjucks, etc, and watch the magic happen: {% raw %}`{% react './path/to/component.jsx' %}`{% endraw %}
+- 🚀 **Unlocks component frameworks** like React for writing page templates and layout templates. Turn an existing `.html` or `.liquid` file into a `.jsx` file, and you're off to the componentized races.
+- 🔖 **Includes powerful shortcodes** to insert components into existing pages. Add a line like this to your markdown, HTML, Nunjucks, etc, and watch the magic happen: {% raw %}`{% react 'path/to/component' %}`{% endraw %}
 - 💧 **Hydrates these components** when and how you want. Use component frameworks as a static template to start, and opt-in to shipping JS as needed with our [partial hydration helpers](/docs/partial-hydration).
-- 💅 **Bundles all your resources** with the power of Vite. Use your favorite CSS preprocessor, JS minifier, and more with the least config possible.
+- 💅 **Bundles all your resources** with the power of Vite. Use your favorite CSS preprocessor, JS minifier, and more with minimal config.

--- a/docs/src/docs/index.md
+++ b/docs/src/docs/index.md
@@ -8,14 +8,14 @@ title: What is Slinkity?
 
 ## Technologies used
 
-Slinkity stands on the shoulders of giants. You can think of Slinkity as the "glue" holding 2 tools together:
+Slinkity stands on the shoulders of giants. You can think of Slinkity as the "glue" binding 2 tools together:
 
 1. [**Eleventy:**](https://www.11ty.dev) a static site generator with a rich feature set for fetching data, composing layouts, and inserting content with "shortcodes."
 2. [**Vite:**](https://vitejs.dev) a bundler that takes the boilerplate out of your set up. It'll compile JS component frameworks, handle CSS preprocessors with little-to-no config (say, SCSS and PostCSS), and show dev changes on-the-fly using [hot module replacement (HMR)](https://vitejs.dev/guide/features.html#hot-module-replacement).
 
 ## Getting started
 
-Use our handy CLI command to spin up a Slinkity site: `npm init slinkity`. This demos our core functionality while keeping as lean as possible, making it the perfect launchpad for new projects.
+{% include 'npm-init-slinkity-snippet.md' %}
 
 To learn more, and explore adding Slinkity to _existing_ 11ty projects...
 
@@ -23,28 +23,28 @@ To learn more, and explore adding Slinkity to _existing_ 11ty projects...
 
 ## Feature set
 
-This project is still in early alpha, so we have many features soon to come! [This demo](https://twitter.com/BHolmesDev/status/1404427102032740353?s=20) covers a majority of features we plan to support. For reference, here's our tentative roadmap to version 1.0:
+This project is still in early alpha, so we have many features soon to come! [This demo](https://www.youtube.com/watch?v=X_zp6CodHjc&t=493s) covers a majority of features we support today. For reference, here's our complete roadmap of current and upcoming features:
 
-| Feature                                        | Status |
-| ---------------------------------------------- | ------ |
-| CLI to run 11ty and Vite simultaneously        | ✅      |
-| React component pages & layouts                | ✅      |
-| React component shortcodes                     | ✅      |
-| SASS support                                   | ✅      |
-| CSS module support*                            | ⏺      |
-| First-class page transition library            | ⏳      |
-| Single page app capabilities                   | ⏳      |
-| Vue component pages, layouts and shortcodes    | ❌      |
-| Svelte component pages, layouts and shortcodes | ❌      |
-| Tailwind support                               | ❌      |
-| Styled components & Emotion support            | ❌      |
+| Feature                                                | Status |
+| ------------------------------------------------------ | ------ |
+| CLI to run 11ty and Vite simultaneously                | ✅      |
+| React component pages & layouts                        | ✅      |
+| React component shortcodes                             | ✅      |
+| SCSS and SASS                                          | ✅      |
+| PostCSS config (ex. Tailwind)                          | ✅      |
+| CSS imports via ESM (including CSS modules) *          | ⏺      |
+| Plugin ecosystem for your favorite component framework |
+| (Vue, Svelte, Solid, etc)                              | ⏳      |
+| Eleventy serverless compatibility                      | ❌      |
+| Shared state between component shortcodes              | ❌      |
+| Styled components & Emotion                            | ❌      |
 
-_*CSS modules **will** work with JavaScript enabled. However, disabling JavaScript or rendering your components as "static" will break this behavior._
+_*CSS imports will work today, but with one caveat: stylesheets will bleed to other routes on your site. We're actively working on a fix!_
 
 - ✅ = Ready to use
 - ⏺ = Partial support
 - ⏳ = In progress
-- ❌ = Not started (but on roadmap)
+- ❌ = Not started, but on roadmap
 
 ## Have an idea? Notice a bug?
 

--- a/docs/src/docs/index.md
+++ b/docs/src/docs/index.md
@@ -1,45 +1,43 @@
 ---
-title: Overview
+title: What is Slinkity?
 ---
 
-> 🚧 **This project is heavily under construction!** 🚧 As excited as you may be, we don't recommend this early alpha for production use. Still, give it a try if you want to have some fun and don't mind [logging bugs](https://github.com/slinkity/slinkity/issues) along the way :)
-
-## In brief
-
-Slinkity is a tool for bringing dynamic, clientside interactions to your static 11ty site. Once installed, this:
-
-- 🚀 **Unlocks component frameworks** (like React) for writing page templates and layout templates. So, you can turn an existing `.html` or `.liquid` file into a `.jsx` file, and immediately start building routes using React.
-- 🔖 **Includes powerful shortcodes** to insert components into existing pages. Add a line like this to your markdown, HTML, Nunjucks, etc, and watch the magic happen: {% raw %}`{% react './path/to/component.jsx' %}`{% endraw %}
-- 💧 **Hydrates these component-driven pages** on the client. In other words, all your dynamic state management will work in development and production with 0 extra setup.
+{% include 'value-props.md' %}
 
 ### [📣 Find our full announcement post here →](/)
 
-### [🐣 Jump in with our "quick start" guide →](/docs/quick-start)
-
 ## Technologies used
 
-Slinkity stands on the shoulders of giants. You can think of Slinkity like the "glue" holding 2 services together:
+Slinkity stands on the shoulders of giants. You can think of Slinkity as the "glue" holding 2 tools together:
 
 1. [**Eleventy:**](https://www.11ty.dev) a static site generator with a rich feature set for fetching data, composing layouts, and inserting content with "shortcodes."
-2. [**Vite:**](https://vitejs.dev) a bundler that takes the boilerplate out of JavaScript development. It'll spin up a dev server for you, re-process components on the fly using [hot module replacement (HMR)](https://vitejs.dev/guide/features.html#hot-module-replacement), and optimize your production build using Rollup.
+2. [**Vite:**](https://vitejs.dev) a bundler that takes the boilerplate out of your set up. It'll compile JS component frameworks, handle CSS preprocessors with little-to-no config (say, SCSS and PostCSS), and show dev changes on-the-fly using [hot module replacement (HMR)](https://vitejs.dev/guide/features.html#hot-module-replacement).
+
+## Getting started
+
+Use our handy CLI command to spin up a Slinkity site: `npm init slinkity`. This demos our core functionality while keeping as lean as possible, making it the perfect launchpad for new projects.
+
+To learn more, and explore adding Slinkity to _existing_ 11ty projects...
+
+### [🐣 See our "quick start" guide →](/docs/quick-start)
 
 ## Feature set
 
 This project is still in early alpha, so we have many features soon to come! [This demo](https://twitter.com/BHolmesDev/status/1404427102032740353?s=20) covers a majority of features we plan to support. For reference, here's our tentative roadmap to version 1.0:
 
-| Feature                                         | Status |
-| ----------------------------------------------- | ------ |
-| CLI to run 11ty and Vite simultaneously         | ✅ | 
-| React component pages & layouts                 | ✅ | 
-| React component shortcodes                      | ✅ |
-| SASS support                                    | ✅ |
-| CSS module support*                             | ⏺ |
-| First-class page transition library             | ⏳ |
-| Single page app capabilities                    | ⏳ |
-| Vue component pages, layouts and shortcodes     | ❌ |
-| Svelte component pages, layouts and shortcodes  | ❌ |
-| Tailwind support                                | ❌ |
-| Styled components & Emotion support             | ❌ |
+| Feature                                        | Status |
+| ---------------------------------------------- | ------ |
+| CLI to run 11ty and Vite simultaneously        | ✅      |
+| React component pages & layouts                | ✅      |
+| React component shortcodes                     | ✅      |
+| SASS support                                   | ✅      |
+| CSS module support*                            | ⏺      |
+| First-class page transition library            | ⏳      |
+| Single page app capabilities                   | ⏳      |
+| Vue component pages, layouts and shortcodes    | ❌      |
+| Svelte component pages, layouts and shortcodes | ❌      |
+| Tailwind support                               | ❌      |
+| Styled components & Emotion support            | ❌      |
 
 _*CSS modules **will** work with JavaScript enabled. However, disabling JavaScript or rendering your components as "static" will break this behavior._
 

--- a/docs/src/docs/quick-start.md
+++ b/docs/src/docs/quick-start.md
@@ -2,38 +2,50 @@
 title: Quick start
 ---
 
-All you need is an empty directory to get started! But if you prefer a starter project with some pre-populated content, you can use the lovely guide + community resources [over on the 11ty docs](https://www.11ty.dev/docs/getting-started/).
+{% include 'npm-init-slinkity-snippet.md' %}
 
-## Installation
+It includes:
+- a React component embedded into a static `.md` template → [more on component shortcodes here](/docs/component-shortcodes/)
+- a route built using a component framework as a templating language → [more on component pages here](/docs/component-pages-layouts/)
+- a `netlify.toml` configured to deploy in a flash → [more on deployment here](/docs/deployment/)
+- an eleventy config with a few recommended defualts → [more on config here](/docs/config/#recommended-config-options)
 
-If you're starting from a new directory, be sure to create a new `package.json` like so:
+## Add to your existing 11ty project
 
-```bash
-npm init -y
-```
+Want to bring Slinkity to your current 11ty project? No sweat! Slinkity is built to slot into your existing workflow 😁
 
-Then, install Slinkity + the latest 11ty into your project:
+### Installation
 
-> Slinkity requires Node v14 and up. You can check your version by running `node -v` in your terminal before trying Slinkity.
+First, install Slinkity + the latest 11ty into your project:
 
 ```bash
 npm i --save-dev slinkity @11ty/eleventy@beta
 ```
 
-> Slinkity relies on 11ty's [latest 1.0 beta build](https://www.npmjs.com/package/@11ty/eleventy/v/beta) to work properly. Yes, this could involve some gotchas with existing 11ty plugins! If anything unexpected happens, let us know on our [GitHub issues page](https://github.com/slinkity/slinkity/issues).
+> Slinkity requires Node v14 and up. You can check your version by running `node -v` in your terminal before trying Slinkity.
 
-...and run our CLI command to spin up the dev server:
+> Slinkity also relies on 11ty's [latest 1.0 beta build](https://www.npmjs.com/package/@11ty/eleventy/v/beta) to work properly. Yes, this could involve some gotchas with existing 11ty plugins! If anything unexpected happens, let us know on our [GitHub issues page](https://github.com/slinkity/slinkity/issues).
+
+### Using the `slinkity` CLI
+
+We supply our own CLI in place of `eleventy`. This spins up Vite and 11ty in a single command, while using the _exact same CLI flags_ you would use with `eleventy` today. So if you have any `"scripts"` in your `package.json`, [feel free to find-and-replace](https://twitter.com/slinkitydotdev/status/1431371307036336128) `eleventy` with `slinkity`.
+
+Let's spin up a dev server for example. This uses the same set of flags as eleventy:
 
 ```bash
-npx slinkity --serve
-# Also consider the --incremental flag
+npx slinkity --serve --incremental
+# we recommend the --incremental flag
 # for faster builds during development
 ```
 
-Now you're off to the races! This command will:
+This command will:
 
 1. Start up [11ty in `--watch` mode](https://www.11ty.dev/docs/usage/#re-run-eleventy-when-you-save) to listen for file changes
-2. Start up [a Vite server](https://vitejs.dev/guide/#index-html-and-project-root) pointed at your 11ty build. This helps us process all sorts of file types, including SASS styles, React components, and more 🚀
+2. Start up [a Vite server](https://vitejs.dev/guide/#index-html-and-project-root) pointed at your 11ty build. This helps us process all sorts of file types, including SCSS styles, React components, and more.
+
+[See our `slinkity` CLI docs](http://localhost:8080/docs/config/#the-slinkity-cli) for more details on how flags are processed.
+
+### Production builds
 
 When you're ready for a production build, just run:
 
@@ -43,11 +55,11 @@ npx slinkity
 
 ...and your shiny new site will appear in the `_site` folder (or [wherever you tell 11ty to build your site](https://www.11ty.dev/docs/config/#output-directory)).
 
-But wait, you might not have any templates to build yet! Let's change that.
+But wait, we haven't tried any of Slinkity's features yet! Let's change that.
 
-## Adding your first component shortcode
+### Adding your first component shortcode
 
-Alright, now let's do something... Slinkity-ish. Say you have a project directory with just 1 file: `index.html`. That file might look like this:
+Say you have a project directory with just 1 file: `index.html`. That file might look like this:
 
 ```html
 <!DOCTYPE html>
@@ -64,12 +76,12 @@ Alright, now let's do something... Slinkity-ish. Say you have a project director
 </html>
 ```
 
-If you run this using the `slinkity --serve` command, you'll just see the gloriously static text "Look ma, it's Slinkity!"
+If you run this using the `slinkity --serve --incremental` command, you'll just see the gloriously static text "Look ma, it's Slinkity!"
 
-Now, let's add something _interactive._ Say we're keeping track of how many glasses of water we've had today (because [hydration is important](https://www.gatsbyjs.com/docs/conceptual/react-hydration/)!). If we know a little [ReactJS](https://reactjs.org/docs/getting-started.html), we can whip up a counter component under the `_includes/components/` directory like so:
+But what if we want something... interactive? For instance, say we're tracking how many glasses of water we've had today (because [hydration is important](https://www.gatsbyjs.com/docs/conceptual/react-hydration/)!). If we know a little [ReactJS](https://reactjs.org/docs/getting-started.html), we can whip up a counter component under the `_includes/` directory like so:
 
 ```jsx
-// _includes/components/GlassCounter.jsx
+// _includes/GlassCounter.jsx
 import React, { useState } from 'react'
 
 function GlassCounter() {
@@ -87,29 +99,29 @@ function GlassCounter() {
 export default GlassCounter
 ```
 
-_**Note:** Make sure this file is under `_includes/components`. Slinkity will copy this directory over to your build._
+_**Note:** Make sure this file is under `_includes`. This is where our component shortcode will look for `GlassCounter` in a moment._
 
-Next, go ahead and install `react` and `react-dom` as project dependencies. This will help your Vite server compile your component.
+Next, install `react` and `react-dom` as project dependencies. You might need to stop and restart your dev server if it's running:
 
 ```bash
 npm i react react-dom
 ```
 
-Now how do we use this component on our `index.html` page? Let's reach for a [shortcode](https://www.11ty.dev/docs/shortcodes/):
+Finally, let's place this component on our `index.html` with a [component shortcode](/docs/component-shortcodes):
 
 ```html
 ...
 <body>
   <h1>Look ma, it's Slinkity!</h1>
-  {% raw %}{% react 'components/GlassCounter' %}{% endraw %}
+  {% raw %}{% react 'GlassCounter' %}{% endraw %}
 </body>
 ```
 
 This will do a few things:
-1. Go find `_includes/component/GlassCounter.jsx` (notice the `_includes` and `.jsx` are optional)
-2. "Statically" render the component and insert it as HTML. This means you'll always see your component, even when disabling JS in your browser ([go try it!](https://developer.chrome.com/docs/devtools/javascript/disable/)).
+1. Go find `_includes/GlassCounter.jsx` (notice the `.jsx` is optional)
+2. Prerender the component at build time and insert it as HTML. This means you'll always see your component, even when disabling JS in your browser ([try it!](https://developer.chrome.com/docs/devtools/javascript/disable/)).
 3. ["Hydrate"](/docs/partial-hydration/) that HTML we just rendered with our JavaScript component
 
-Now in your browser preview, clicking the button should increase your counter 🎉
+Now in your browser preview, clicking "Add one" should increase your counter 🎉
 
 ### [Learn more about component shortcodes →](/docs/component-shortcodes)

--- a/docs/src/docs/quick-start.md
+++ b/docs/src/docs/quick-start.md
@@ -118,9 +118,9 @@ Finally, let's place this component on our `index.html` with a [component shortc
 ```
 
 This will do a few things:
-1. Go find `_includes/GlassCounter.jsx` (notice the `.jsx` is optional)
-2. Prerender the component at build time and insert it as HTML. This means you'll always see your component, even when disabling JS in your browser ([try it!](https://developer.chrome.com/docs/devtools/javascript/disable/)).
-3. ["Hydrate"](/docs/partial-hydration/) that HTML we just rendered with our JavaScript component
+1. Find `_includes/GlassCounter.jsx` (notice the `.jsx` is optional)
+2. [Prerender](https://jamstack.org/glossary/pre-render/) your component at build time. This means you'll always see your component, even when disabling JS in your browser ([try it!](https://developer.chrome.com/docs/devtools/javascript/disable/)).
+3. ["Hydrate"](/docs/partial-hydration/) that prerendered component with JavaScript
 
 Now in your browser preview, clicking "Add one" should increase your counter 🎉
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,11 +8,7 @@ layout: home
 
 ## What is it?
 
-Slinkity is a plugin that can extend any [11ty](https://11ty.dev/) site. Once installed, this:
-- 🚀 **Unlocks component frameworks** (React, Vue, and Svelte) for writing page templates _and_ layout templates. So you can turn an existing `.html` or `.liquid` file into a `.jsx` file, and immediately start building routes on your site using React.
-- 🔖 **Includes powerful shortcodes** to insert components into existing pages. Add a line like this to your markdown, HTML, Nunjucks, etc, and watch the magic happen: `{% raw %}{% react './path/to/component.jsx' %}{% endraw %}`
-- 💧 **Hydrates these component-driven pages** on the client. In other words, all your [dynamic state management](https://reactjs.org/docs/hooks-intro.html) will work in development and production with 0 extra setup.
-- 🔗 **(Optionally) Turns your site into a single page app.** This opens the door for animated page transitions, persistent state between pages, and more!
+{% include 'value-props.md' %}
 
 Let's see Slinkity in action ✨
 


### PR DESCRIPTION
Resolves #108 

- add `npm init slinkity` call-out to docs homepage and quick start
- change "Overview" title to "What is Slinkity?" for clarity
- extract value props to a shared snippet so the homepage and docs stay aligned (also tweaked to fully cover our featureset)
- update feature set on overview page based on our current roadmap