### PR TITLE
Fix: resolve CSS imports via ESM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3044,6 +3044,12 @@
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.29.tgz",
       "integrity": "sha512-w/XuoBCSwepyiZtIRsKsetiLDUVGPVw1E/R3VTFSecIy8UR7Cq3SOtwKHJMFoVqqVG36aGkzh4e8BvpO1Fdc7g=="
     },
+    "esbuild-android-arm64": {
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.15.tgz",
+      "integrity": "sha512-m602nft/XXeO8YQPUDVoHfjyRVPdPgjyyXOxZ44MK/agewFFkPa8tUo6lAzSWh5Ui5PB4KR9UIFTSBKh/RrCmg==",
+      "optional": true
+    },
     "esbuild-css-modules-plugin": {
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/esbuild-css-modules-plugin/-/esbuild-css-modules-plugin-2.0.9.tgz",
@@ -3068,6 +3074,102 @@
           }
         }
       }
+    },
+    "esbuild-darwin-64": {
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.15.tgz",
+      "integrity": "sha512-ihOQRGs2yyp7t5bArCwnvn2Atr6X4axqPpEdCFPVp7iUj4cVSdisgvEKdNR7yH3JDjW6aQDw40iQFoTqejqxvQ==",
+      "optional": true
+    },
+    "esbuild-darwin-arm64": {
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.15.tgz",
+      "integrity": "sha512-i1FZssTVxUqNlJ6cBTj5YQj4imWy3m49RZRnHhLpefFIh0To05ow9DTrXROTE1urGTQCloFUXTX8QfGJy1P8dQ==",
+      "optional": true
+    },
+    "esbuild-freebsd-64": {
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.15.tgz",
+      "integrity": "sha512-G3dLBXUI6lC6Z09/x+WtXBXbOYQZ0E8TDBqvn7aMaOCzryJs8LyVXKY4CPnHFXZAbSwkCbqiPuSQ1+HhrNk7EA==",
+      "optional": true
+    },
+    "esbuild-freebsd-arm64": {
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.15.tgz",
+      "integrity": "sha512-KJx0fzEDf1uhNOZQStV4ujg30WlnwqUASaGSFPhznLM/bbheu9HhqZ6mJJZM32lkyfGJikw0jg7v3S0oAvtvQQ==",
+      "optional": true
+    },
+    "esbuild-linux-32": {
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.15.tgz",
+      "integrity": "sha512-ZvTBPk0YWCLMCXiFmD5EUtB30zIPvC5Itxz0mdTu/xZBbbHJftQgLWY49wEPSn2T/TxahYCRDWun5smRa0Tu+g==",
+      "optional": true
+    },
+    "esbuild-linux-64": {
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.15.tgz",
+      "integrity": "sha512-eCKzkNSLywNeQTRBxJRQ0jxRCl2YWdMB3+PkWFo2BBQYC5mISLIVIjThNtn6HUNqua1pnvgP5xX0nHbZbPj5oA==",
+      "optional": true
+    },
+    "esbuild-linux-arm": {
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.15.tgz",
+      "integrity": "sha512-wUHttDi/ol0tD8ZgUMDH8Ef7IbDX+/UsWJOXaAyTdkT7Yy9ZBqPg8bgB/Dn3CZ9SBpNieozrPRHm0BGww7W/jA==",
+      "optional": true
+    },
+    "esbuild-linux-arm64": {
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.15.tgz",
+      "integrity": "sha512-bYpuUlN6qYU9slzr/ltyLTR9YTBS7qUDymO8SV7kjeNext61OdmqFAzuVZom+OLW1HPHseBfJ/JfdSlx8oTUoA==",
+      "optional": true
+    },
+    "esbuild-linux-mips64le": {
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.15.tgz",
+      "integrity": "sha512-KlVjIG828uFPyJkO/8gKwy9RbXhCEUeFsCGOJBepUlpa7G8/SeZgncUEz/tOOUJTcWMTmFMtdd3GElGyAtbSWg==",
+      "optional": true
+    },
+    "esbuild-linux-ppc64le": {
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.15.tgz",
+      "integrity": "sha512-h6gYF+OsaqEuBjeesTBtUPw0bmiDu7eAeuc2OEH9S6mV9/jPhPdhOWzdeshb0BskRZxPhxPOjqZ+/OqLcxQwEQ==",
+      "optional": true
+    },
+    "esbuild-netbsd-64": {
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.15.tgz",
+      "integrity": "sha512-3+yE9emwoevLMyvu+iR3rsa+Xwhie7ZEHMGDQ6dkqP/ndFzRHkobHUKTe+NCApSqG5ce2z4rFu+NX/UHnxlh3w==",
+      "optional": true
+    },
+    "esbuild-openbsd-64": {
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.15.tgz",
+      "integrity": "sha512-wTfvtwYJYAFL1fSs8yHIdf5GEE4NkbtbXtjLWjM3Cw8mmQKqsg8kTiqJ9NJQe5NX/5Qlo7Xd9r1yKMMkHllp5g==",
+      "optional": true
+    },
+    "esbuild-sunos-64": {
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.15.tgz",
+      "integrity": "sha512-lbivT9Bx3t1iWWrSnGyBP9ODriEvWDRiweAs69vI+miJoeKwHWOComSRukttbuzjZ8r1q0mQJ8Z7yUsDJ3hKdw==",
+      "optional": true
+    },
+    "esbuild-windows-32": {
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.15.tgz",
+      "integrity": "sha512-fDMEf2g3SsJ599MBr50cY5ve5lP1wyVwTe6aLJsM01KtxyKkB4UT+fc5MXQFn3RLrAIAZOG+tHC+yXObpSn7Nw==",
+      "optional": true
+    },
+    "esbuild-windows-64": {
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.15.tgz",
+      "integrity": "sha512-9aMsPRGDWCd3bGjUIKG/ZOJPKsiztlxl/Q3C1XDswO6eNX/Jtwu4M+jb6YDH9hRSUflQWX0XKAfWzgy5Wk54JQ==",
+      "optional": true
+    },
+    "esbuild-windows-arm64": {
+      "version": "0.13.15",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.15.tgz",
+      "integrity": "sha512-zzvyCVVpbwQQATaf3IG8mu1IwGEiDxKkYUdA4FpoCHi1KtPa13jeScYDjlW0Qh+ebWzpKfR2ZwvqAQkSWNcKjA==",
+      "optional": true
     },
     "escalade": {
       "version": "3.1.1",
@@ -5822,6 +5924,11 @@
         }
       }
     },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+    },
     "picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -6252,9 +6359,9 @@
       }
     },
     "rollup": {
-      "version": "2.56.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.56.0.tgz",
-      "integrity": "sha512-weEafgbjbHCnrtJPNyCrhYnjP62AkF04P0BcV/1mofy1+gytWln4VVB1OK462cq2EAyWzRDpTMheSP/o+quoiA==",
+      "version": "2.62.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.62.0.tgz",
+      "integrity": "sha512-cJEQq2gwB0GWMD3rYImefQTSjrPYaC6s4J9pYqnstVLJ1CHa/aZNVkD4Epuvg4iLeMA4KRiq7UM7awKK6j7jcw==",
       "requires": {
         "fsevents": "~2.3.2"
       }
@@ -7301,15 +7408,61 @@
       }
     },
     "vite": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.4.4.tgz",
-      "integrity": "sha512-m1wK6pFJKmaYA6AeZIUXyiAgUAAJzVXhIMYCdZUpCaFMGps0v0IlNJtbmPvkUhVEyautalajmnW5X6NboUPsnw==",
+      "version": "2.7.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.7.10.tgz",
+      "integrity": "sha512-KEY96ntXUid1/xJihJbgmLZx7QSC2D4Tui0FdS0Old5OokYzFclcofhtxtjDdGOk/fFpPbHv9yw88+rB93Tb8w==",
       "requires": {
-        "esbuild": "^0.12.8",
+        "esbuild": "^0.13.12",
         "fsevents": "~2.3.2",
-        "postcss": "^8.3.6",
+        "postcss": "^8.4.5",
         "resolve": "^1.20.0",
-        "rollup": "^2.38.5"
+        "rollup": "^2.59.0"
+      },
+      "dependencies": {
+        "esbuild": {
+          "version": "0.13.15",
+          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.15.tgz",
+          "integrity": "sha512-raCxt02HBKv8RJxE8vkTSCXGIyKHdEdGfUmiYb8wnabnaEmHzyW7DCHb5tEN0xU8ryqg5xw54mcwnYkC4x3AIw==",
+          "requires": {
+            "esbuild-android-arm64": "0.13.15",
+            "esbuild-darwin-64": "0.13.15",
+            "esbuild-darwin-arm64": "0.13.15",
+            "esbuild-freebsd-64": "0.13.15",
+            "esbuild-freebsd-arm64": "0.13.15",
+            "esbuild-linux-32": "0.13.15",
+            "esbuild-linux-64": "0.13.15",
+            "esbuild-linux-arm": "0.13.15",
+            "esbuild-linux-arm64": "0.13.15",
+            "esbuild-linux-mips64le": "0.13.15",
+            "esbuild-linux-ppc64le": "0.13.15",
+            "esbuild-netbsd-64": "0.13.15",
+            "esbuild-openbsd-64": "0.13.15",
+            "esbuild-sunos-64": "0.13.15",
+            "esbuild-windows-32": "0.13.15",
+            "esbuild-windows-64": "0.13.15",
+            "esbuild-windows-arm64": "0.13.15"
+          }
+        },
+        "nanoid": {
+          "version": "3.1.30",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
+          "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ=="
+        },
+        "postcss": {
+          "version": "8.4.5",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
+          "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
+          "requires": {
+            "nanoid": "^3.1.30",
+            "picocolors": "^1.0.0",
+            "source-map-js": "^1.0.1"
+          }
+        },
+        "source-map-js": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.1.tgz",
+          "integrity": "sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA=="
+        }
       }
     },
     "w3c-hr-time": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "node-html-parser": "^5.1.0",
     "require-from-string": "^2.0.2",
     "sass": "^1.36.0",
-    "vite": "^2.4.4"
+    "vite": "^2.7.10"
   },
   "peerDependencies": {
     "@11ty/eleventy": "^1.0.0-beta.3"

--- a/src/cli/eleventy.js
+++ b/src/cli/eleventy.js
@@ -3,7 +3,7 @@ const Eleventy = require('@11ty/eleventy/src/Eleventy')
 const EleventyErrorHandler = require('@11ty/eleventy/src/EleventyErrorHandler')
 const UserConfig = require('@11ty/eleventy/src/UserConfig')
 const { resolve } = require('path')
-const toViteSSR = require('./toViteSSR')
+const { toViteSSR } = require('./toViteSSR')
 const { readUserSlinkityConfig } = require('./readUserSlinkityConfig')
 const slinkityConfig = require('../plugin')
 

--- a/src/cli/toViteSSR.js
+++ b/src/cli/toViteSSR.js
@@ -26,10 +26,11 @@ function collectCSS(mod, collectedCSSModUrls, visitedModUrls = new Set()) {
   visitedModUrls.add(mod.url)
   if (isStyleImport(mod.url)) {
     collectedCSSModUrls.add(mod.url)
+  } else {
+    mod.importedModules.forEach((subMod) => {
+      collectCSS(subMod, collectedCSSModUrls, visitedModUrls)
+    })
   }
-  mod.importedModules.forEach((subMod) => {
-    collectCSS(subMod, collectedCSSModUrls, visitedModUrls)
-  })
 }
 
 /**

--- a/src/cli/toViteSSR.js
+++ b/src/cli/toViteSSR.js
@@ -67,7 +67,7 @@ async function viteBuild({ dir, ssrViteConfig, filePath, environment }) {
     })
     return defaultMod
   }
-  const __importedStyles = Object.keys(output[0].modules ?? {}).filter(isStyleImport)
+  const __importedStyles = new Set(Object.keys(output[0].modules ?? {}).filter(isStyleImport))
   return {
     ...defaultMod,
     __importedStyles,

--- a/src/cli/toViteSSR.js
+++ b/src/cli/toViteSSR.js
@@ -10,7 +10,7 @@ const { getSharedConfig } = require('./vite')
  * @returns Whether this import ends with an expected CSS file extension
  */
 function isStyleImport(imp) {
-  return /\.(css|scss|sass|less|stylus)$/.test(imp)
+  return /\.(css|scss|sass|less|stylus)($|\?*)/.test(imp)
 }
 
 /**

--- a/src/cli/toViteSSR.js
+++ b/src/cli/toViteSSR.js
@@ -105,7 +105,7 @@ async function viteBuild({ dir, ssrViteConfig, filePath, environment }) {
  *
  * @returns {ViteSSR} viteSSR
  */
-module.exports.default = async function toViteSSR({ environment, dir }) {
+async function toViteSSR({ environment, dir }) {
   const ssrViteConfig = defineConfig({ root: dir.output })
   /** @type {Record<string, FormattedModule>} */
   const probablyInefficientCache = {}
@@ -180,3 +180,5 @@ module.exports.default = async function toViteSSR({ environment, dir }) {
     }
   }
 }
+
+module.exports.toViteSSR = toViteSSR

--- a/src/cli/toViteSSR.js
+++ b/src/cli/toViteSSR.js
@@ -53,23 +53,24 @@ async function viteBuild({ dir, ssrViteConfig, filePath, environment }) {
       },
     },
   })
-  const __importedStyles = Object.keys(output[0].modules).filter(isStyleImport)
   /** @type {FormattedModule} */
-  const mod = {
+  const defaultMod = {
     default: () => null,
     getProps: () => ({}),
     frontMatter: {},
-    __importedStyles,
+    __importedStyles: new Set(),
   }
   if (!output?.length) {
     logger.log({
       type: 'error',
       message: `Module ${filePath} didn't have any output. Is this file blank?`,
     })
-    return mod
+    return defaultMod
   }
+  const __importedStyles = Object.keys(output[0].modules ?? {}).filter(isStyleImport)
   return {
-    ...mod,
+    ...defaultMod,
+    __importedStyles,
     // converts our stringified JS to a CommonJS module in memory
     // saves reading / writing to disk!
     // TODO: check performance impact

--- a/src/cli/toViteSSR.js
+++ b/src/cli/toViteSSR.js
@@ -13,6 +13,8 @@ function isStyleImport(imp) {
   return /\.(css|scss|sass|less|stylus)($|\?*)/.test(imp)
 }
 
+module.exports.isStyleImport = isStyleImport
+
 /**
  * Recursively walks through all nested imports for a given module,
  * Searching for any CSS imported via ESM
@@ -101,7 +103,7 @@ async function viteBuild({ dir, ssrViteConfig, filePath, environment }) {
  *
  * @returns {ViteSSR} viteSSR
  */
-module.exports = async function toViteSSR({ environment, dir }) {
+module.exports.default = async function toViteSSR({ environment, dir }) {
   const ssrViteConfig = defineConfig({ root: dir.output })
   /** @type {Record<string, FormattedModule>} */
   const probablyInefficientCache = {}

--- a/src/cli/toViteSSR.js
+++ b/src/cli/toViteSSR.js
@@ -35,6 +35,8 @@ function collectCSS(mod, collectedCSSModUrls, visitedModUrls = new Set()) {
   }
 }
 
+module.exports.collectCSS = collectCSS
+
 /**
  * Production-style build using Vite's build CLI
  * @param {ViteSSRParams & {

--- a/src/cli/toViteSSR.js
+++ b/src/cli/toViteSSR.js
@@ -4,33 +4,32 @@ const logger = require('../utils/logger')
 const { getSharedConfig } = require('./vite')
 
 /**
- * @typedef {import('./reactPlugin/2-pageTransform/componentAttrStore').ComponentAttrs['styleToFilePathMap']} StyleToFilePathMap
- * @typedef GimmeCSSPluginReturn
- * @property {() => StyleToFilePathMap} getCSS
- * @property {import('vite').PluginOption}
- * @returns {GimmeCSSPluginReturn}
+ * Regex of hard-coded stylesheet extensions
+ * TODO: generate regex from applied Vite plugins
+ * @param {string} imp Import to test
+ * @returns Whether this import ends with an expected CSS file extension
  */
-function gimmeCSSPlugin() {
-  /**
-   * @type {StyleToFilePathMap}
-   */
-  const styleToFilePathMap = {}
+function isStyleImport(imp) {
+  return /\.(css|scss|sass|less|stylus)$/.test(imp)
+}
 
-  return {
-    getCSS() {
-      return styleToFilePathMap
-    },
-    plugin: {
-      name: 'gimme-css-plugin',
-      transform(code, id) {
-        if (/\.(css|scss|sass|less|stylus)$/.test(id)) {
-          styleToFilePathMap[id] = code
-          return { code: '' }
-        }
-        return null
-      },
-    },
+/**
+ * Recursively walks through all nested imports for a given module,
+ * Searching for any CSS imported via ESM
+ * @param {import('vite').ModuleNode | undefined} mod The module node to collect CSS from
+ * @param {Set<string>} collectedCSSModUrls All CSS imports found
+ * @param {Set<string>} visitedModUrls All modules recursively crawled
+ */
+function collectCSS(mod, collectedCSSModUrls, visitedModUrls = new Set()) {
+  if (!mod || !mod.url || visitedModUrls.has(mod.url)) return
+
+  visitedModUrls.add(mod.url)
+  if (isStyleImport(mod.url)) {
+    collectedCSSModUrls.add(mod.url)
   }
+  mod.importedModules.forEach((subMod) => {
+    collectCSS(subMod, visitedModUrls, collectedCSSModUrls)
+  })
 }
 
 /**
@@ -38,11 +37,10 @@ function gimmeCSSPlugin() {
  * @param {ViteSSRParams & {
  *  ssrViteConfig: import('vite').UserConfigExport;
  *  filePath: string;
- *  generatedStyles: GimmeCSSPluginReturn;
  * }} params
  * @returns {FormattedModule}
  */
-async function viteBuild({ dir, ssrViteConfig, filePath, environment, generatedStyles }) {
+async function viteBuild({ dir, ssrViteConfig, filePath, environment }) {
   const { output } = await build({
     ...ssrViteConfig,
     ...(await getSharedConfig(dir)),
@@ -55,14 +53,13 @@ async function viteBuild({ dir, ssrViteConfig, filePath, environment, generatedS
       },
     },
   })
-  /**
-   * @type {FormattedModule}
-   */
+  const __importedStyles = Object.keys(output[0].modules).filter(isStyleImport)
+  /** @type {FormattedModule} */
   const mod = {
     default: () => null,
     getProps: () => ({}),
     frontMatter: {},
-    __stylesGenerated: generatedStyles.getCSS(),
+    __importedStyles,
   }
   if (!output?.length) {
     logger.log({
@@ -86,12 +83,11 @@ async function viteBuild({ dir, ssrViteConfig, filePath, environment, generatedS
  * @property {import('../plugin').SlinkityConfigOptions['dir']} dir
  * @param {ViteSSRParams}
  *
- * @typedef {{
- *  default: () => any;
- *  getProps: (eleventyData: any) => any;
- *  frontMatter: Record<string, any>;
- *  __stylesGenerated: Record<string, string>;
- * }} FormattedModule - expected keys from a given component module
+ * @typedef FormattedModule
+ * @property {() => any} default
+ * @property {(eleventyData: any) => any} getProps
+ * @property {Record<string, any>} frontMatter
+ * @property {Set<string>} __importedStyles
  *
  * @typedef ToCommonJSModuleOptions
  * @property {boolean} useCache Whether to (attempt to) use the in-memory cache for fetching a build result. Defaults to true in production
@@ -104,44 +100,38 @@ async function viteBuild({ dir, ssrViteConfig, filePath, environment, generatedS
  * @returns {ViteSSR} viteSSR
  */
 module.exports = async function toViteSSR({ environment, dir }) {
-  const generatedStyles = gimmeCSSPlugin()
-  const ssrViteConfig = defineConfig({
-    root: dir.output,
-    plugins: [generatedStyles.plugin],
-  })
-  /**
-   * @type {Record<string, FormattedModule>}
-   */
+  const ssrViteConfig = defineConfig({ root: dir.output })
+  /** @type {Record<string, FormattedModule>} */
   const probablyInefficientCache = {}
 
   if (environment === 'dev') {
-    /**
-     * @type {import('vite').ViteDevServer}
-     */
+    /** @type {import('vite').ViteDevServer} */
     let server = null
     return {
       async toCommonJSModule(filePath, options = { useCache: false }) {
         if (options.useCache && probablyInefficientCache[filePath]) {
           return probablyInefficientCache[filePath]
         }
-        /**
-         * @type {FormattedModule}
-         */
+        /** @type {FormattedModule} */
         let viteOutput
         if (server) {
+          const ssrModule = await server.ssrLoadModule(filePath)
+          const moduleGraph = await server.moduleGraph.getModuleByUrl(filePath)
+          /** @type {Set<string>} */
+          const __importedStyles = new Set()
+          collectCSS(moduleGraph, __importedStyles)
           viteOutput = {
             default: () => null,
             getProps: () => ({}),
             frontMatter: {},
-            __stylesGenerated: generatedStyles.getCSS(),
-            ...(await server.ssrLoadModule(filePath)),
+            __importedStyles,
+            ...ssrModule,
           }
         } else {
           viteOutput = await viteBuild({
             dir,
             filePath,
             ssrViteConfig,
-            generatedStyles,
             environment,
           })
         }
@@ -171,7 +161,6 @@ module.exports = async function toViteSSR({ environment, dir }) {
         const viteOutput = await viteBuild({
           dir,
           filePath,
-          generatedStyles,
           ssrViteConfig,
           environment,
         })

--- a/src/cli/toViteSSR.js
+++ b/src/cli/toViteSSR.js
@@ -28,7 +28,7 @@ function collectCSS(mod, collectedCSSModUrls, visitedModUrls = new Set()) {
     collectedCSSModUrls.add(mod.url)
   }
   mod.importedModules.forEach((subMod) => {
-    collectCSS(subMod, visitedModUrls, collectedCSSModUrls)
+    collectCSS(subMod, collectedCSSModUrls, visitedModUrls)
   })
 }
 

--- a/src/cli/toViteSSR.test.js
+++ b/src/cli/toViteSSR.test.js
@@ -1,6 +1,10 @@
-const { isStyleImport } = require('./toViteSSR')
+const { isStyleImport, collectCSS } = require('./toViteSSR')
 
 const cssExtensions = ['css', 'scss', 'sass', 'less', 'stylus']
+
+function toConvincingUrl(fileName) {
+  return `/@fs/Users/person/project/${fileName}`
+}
 
 describe('toViteSSR', () => {
   describe('isStyleImport', () => {
@@ -17,6 +21,120 @@ describe('toViteSSR', () => {
     })
     it('should be false for non-CSS extensions', () => {
       expect(isStyleImport('cool/path.jsx')).toEqual(false)
+    })
+  })
+  describe('collectCSS', () => {
+    it('should generate set of CSS imports from flat module set', () => {
+      const expected = ['base.css', 'scoped.module.scss', 'fancy.stylus'].map(toConvincingUrl)
+      const mod = {
+        url: toConvincingUrl('base.js'),
+        importedModules: new Set([
+          {
+            url: expected[0],
+            importedModules: new Set(),
+          },
+          {
+            url: expected[1],
+            importedModules: new Set(),
+          },
+          {
+            url: expected[1],
+            importedModules: new Set(),
+          },
+          {
+            url: expected[2],
+            importedModules: new Set(),
+          },
+          {
+            url: toConvincingUrl('ImageCarousel.svelte'),
+            importedModules: new Set(),
+          },
+          {
+            url: toConvincingUrl('Component.jsx'),
+            importedModules: new Set(),
+          },
+        ]),
+      }
+      /** @type {Set<string>} */
+      const collectedCSS = new Set()
+      collectCSS(mod, collectedCSS)
+      expect(collectedCSS).toEqual(new Set(expected))
+    })
+    it('should generate set of CSS imports from nested module sets', () => {
+      const expected = ['global.css', 'NestedStyles.module.scss'].map(toConvincingUrl)
+      /** @type {import('vite').ModuleNode} */
+      const mod = {
+        url: toConvincingUrl('base.js'),
+        importedModules: new Set([
+          {
+            url: toConvincingUrl('NestedComponent.jsx'),
+            importedModules: new Set([
+              {
+                url: expected[0],
+                importedModules: new Set(),
+              },
+              {
+                url: expected[1],
+                importedModules: new Set(),
+              },
+            ]),
+          },
+          {
+            url: toConvincingUrl('OtherNestedComponent.jsx'),
+            importedModules: new Set(),
+          },
+          {
+            url: toConvincingUrl('ImageCarousel.svelte'),
+            importedModules: new Set([
+              {
+                url: expected[1],
+                importedModules: new Set(),
+              },
+              {
+                url: toConvincingUrl('NestedComponent.aardvark'),
+                importedModules: new Set(),
+              },
+            ]),
+          },
+        ]),
+      }
+      /** @type {Set<string>} */
+      const collectedCSS = new Set()
+      collectCSS(mod, collectedCSS)
+      expect(collectedCSS).toEqual(new Set(expected))
+    })
+    it('should ignore null or undefined modules', () => {
+      const expected = ['global.css', 'NestedStyles.module.scss'].map(toConvincingUrl)
+      /** @type {import('vite').ModuleNode} */
+      const mod = {
+        url: toConvincingUrl('base.js'),
+        importedModules: new Set([
+          {
+            url: toConvincingUrl('NestedComponent.jsx'),
+            importedModules: new Set([
+              {
+                url: expected[0],
+                importedModules: new Set(),
+              },
+              {
+                url: expected[1],
+                importedModules: new Set(),
+              },
+              null,
+              undefined,
+            ]),
+          },
+          {
+            url: toConvincingUrl('OtherNestedComponent.jsx'),
+            importedModules: new Set(),
+          },
+          undefined,
+        ]),
+      }
+      /** @type {Set<string>} */
+      const collectedCSS = new Set()
+      collectCSS(mod, collectedCSS)
+      expect(collectedCSS).toEqual(new Set(expected))
     })
   })
 })

--- a/src/cli/toViteSSR.test.js
+++ b/src/cli/toViteSSR.test.js
@@ -1,0 +1,22 @@
+const { isStyleImport } = require('./toViteSSR')
+
+const cssExtensions = ['css', 'scss', 'sass', 'less', 'stylus']
+
+describe('toViteSSR', () => {
+  describe('isStyleImport', () => {
+    it.each(cssExtensions)('should be true on the .%s extension', (extension) => {
+      expect(isStyleImport(`/super/cool/path.${extension}`)).toEqual(true)
+    })
+    it.each(cssExtensions)('should be true with query params after .%s extension', (extension) => {
+      // Rollup can append query params like ?used to its modules
+      // Yes, it's annoying. Let's test for it!
+      expect(isStyleImport(`very/neat/path.${extension}?used`)).toEqual(true)
+    })
+    it('should be false for invalid paths', () => {
+      expect(isStyleImport('im not a path....')).toEqual(false)
+    })
+    it('should be false for non-CSS extensions', () => {
+      expect(isStyleImport('cool/path.jsx')).toEqual(false)
+    })
+  })
+})

--- a/src/plugin/applyViteHtmlTransform.js
+++ b/src/plugin/applyViteHtmlTransform.js
@@ -42,12 +42,19 @@ async function applyViteHtmlTransform(
       })
     }
   }
-  root.querySelector('head')?.insertAdjacentHTML(
-    'beforeend',
-    `<script type="module">
-${[...importedStyles].map((importedStyle) => `import ${JSON.stringify(importedStyle)};\n`)}
-</script>`,
-  )
+  if (importedStyles.size) {
+    root
+      .querySelector('head')
+      .insertAdjacentHTML(
+        'beforeend',
+        [...importedStyles]
+          .map(
+            (importedStyle) =>
+              `<link rel="stylesheet" href=${JSON.stringify(importedStyle)}></link>`,
+          )
+          .join('\n'),
+      )
+  }
 
   const routePath = '/' + toSlashesTrimmed(relative(dir.output, outputPath))
   const server = viteSSR.getServer()


### PR DESCRIPTION
Resolves #112 
Resolves #109 

## What changed?
- upgrade to latest Vite version - ensures Vite still finds `scss` imports appended by middleware
- ditch old approach to finding CSS imports. Now crawling the module imports for each component as [recommended by the Vite SSR project](https://github.com/brillout/vite-plugin-ssr/commit/debb9bdbc72d0674066541e39362810d7127b161#diff-5b728e58b78bfac491cdfdb37938c371dba95e164f42748bcec6e5c51db10faeR119-R137)
- inject each imported style as a `<link>` in the `head` -> no more potentially empty `style` tags 👍 