### PR TITLE
Add screenreader-friendly labels for feature progress table

### DIFF
--- a/www/.eleventy.js
+++ b/www/.eleventy.js
@@ -2,6 +2,7 @@ const syntaxHighlight = require('@11ty/eleventy-plugin-syntaxhighlight')
 const yaml = require('js-yaml')
 const markdownIt = require('markdown-it')
 const markdownItAnchor = require('markdown-it-anchor')
+const convertEmojiToAccessibleProgress = require('./src/utils/feature-progress-shortcode')
 
 module.exports = function config(eleventyConfig) {
   // Render headline anchors in the most accessible way, according to Amber Wilson: https://amberwilson.co.uk/blog/are-your-anchor-links-accessible/#accessibility-check
@@ -27,6 +28,8 @@ module.exports = function config(eleventyConfig) {
     }
   }
   const markdownConfigured = markdownIt({ html: true }).use(markdownItAnchor, markdownItAnchorSettings)
+
+  eleventyConfig.addShortcode('featureProgress', convertEmojiToAccessibleProgress)
 
   eleventyConfig.setLibrary('md', markdownConfigured)
   eleventyConfig.addPassthroughCopy('public')

--- a/www/src/docs/index.md
+++ b/www/src/docs/index.md
@@ -25,19 +25,18 @@ To learn more, and explore adding Slinkity to _existing_ 11ty projects...
 
 This project is still in early alpha, so we have many features soon to come! [This demo](https://www.youtube.com/watch?v=X_zp6CodHjc&t=493s) covers a majority of features we support today. For reference, here's our complete roadmap of current and upcoming features:
 
-| Feature                                                | Status |
-| ------------------------------------------------------ | ------ |
-| CLI to run 11ty and Vite simultaneously                | ✅      |
-| React component pages & layouts                        | ✅      |
-| React component shortcodes                             | ✅      |
-| SCSS and SASS                                          | ✅      |
-| PostCSS config (ex. Tailwind)                          | ✅      |
-| CSS imports via ESM (including CSS modules) *          | ⏺      |
-| Plugin ecosystem for your favorite component framework |
-| (Vue, Svelte, Solid, etc)                              | ⏳      |
-| Eleventy serverless compatibility                      | ❌      |
-| Shared state between component shortcodes              | ❌      |
-| Styled components & Emotion                            | ❌      |
+| Feature                                                                               | Status |
+|---------------------------------------------------------------------------------------|--------|
+| CLI to run 11ty and Vite simultaneously                                               | ✅      |
+| React component pages & layouts                                                       | ✅      |
+| React component shortcodes                                                            | ✅      |
+| SCSS and SASS                                                                         | ✅      |
+| PostCSS config (ex. Tailwind)                                                         | ✅      |
+| CSS imports via ESM (including CSS modules) *                                         | ⏺      |
+| Plugin ecosystem for your favorite component framework<br />(Vue, Svelte, Solid, etc) | ⏳      |
+| Eleventy serverless compatibility                                                     | ❌      |
+| Shared state between component shortcodes                                             | ❌      |
+| Styled components & Emotion                                                           | ❌      |
 
 _*CSS imports will work today, but with one caveat: stylesheets will bleed to other routes on your site. We're actively working on a fix!_
 

--- a/www/src/docs/index.md
+++ b/www/src/docs/index.md
@@ -25,18 +25,18 @@ To learn more, and explore adding Slinkity to _existing_ 11ty projects...
 
 This project is still in early alpha, so we have many features soon to come! [This demo](https://www.youtube.com/watch?v=X_zp6CodHjc&t=493s) covers a majority of features we support today. For reference, here's our complete roadmap of current and upcoming features:
 
-| Feature                                                                               | Status |
-|---------------------------------------------------------------------------------------|--------|
-| CLI to run 11ty and Vite simultaneously                                               | ✅      |
-| React component pages & layouts                                                       | ✅      |
-| React component shortcodes                                                            | ✅      |
-| SCSS and SASS                                                                         | ✅      |
-| PostCSS config (ex. Tailwind)                                                         | ✅      |
-| CSS imports via ESM (including CSS modules) *                                         | ⏺      |
-| Plugin ecosystem for your favorite component framework<br />(Vue, Svelte, Solid, etc) | ⏳      |
-| Eleventy serverless compatibility                                                     | ❌      |
-| Shared state between component shortcodes                                             | ❌      |
-| Styled components & Emotion                                                           | ❌      |
+| Feature                                                                               | Status                    |
+|---------------------------------------------------------------------------------------|---------------------------|
+| CLI to run 11ty and Vite simultaneously                                               | {% featureProgress '✅' %} |
+| React component pages & layouts                                                       | {% featureProgress '✅' %} |
+| React component shortcodes                                                            | {% featureProgress '✅' %} |
+| SCSS and SASS                                                                         | {% featureProgress '✅' %} |
+| PostCSS config (ex. Tailwind)                                                         | {% featureProgress '✅' %} |
+| CSS imports via ESM (including CSS modules) *                                         | {% featureProgress '⏺' %} |
+| Plugin ecosystem for your favorite component framework<br />(Vue, Svelte, Solid, etc) | {% featureProgress '⏳' %} |
+| Eleventy serverless compatibility                                                     | {% featureProgress '❌' %} |
+| Shared state between component shortcodes                                             | {% featureProgress '❌' %} |
+| Styled components & Emotion                                                           | {% featureProgress '❌' %} |
 
 _*CSS imports will work today, but with one caveat: stylesheets will bleed to other routes on your site. We're actively working on a fix!_
 

--- a/www/src/utils/feature-progress-shortcode.js
+++ b/www/src/utils/feature-progress-shortcode.js
@@ -1,0 +1,32 @@
+/*
+- ✅ = Ready to use
+- ⏺ = Partial support
+- ⏳ = In progress
+- ❌ = Not started, but on roadmap
+*/
+const EMOJI_KEY = {
+  '✅': 'Ready to use',
+  '⏺': 'Partial support',
+  '⏳': 'In progress',
+  '❌': 'Not started, but on roadmap',
+}
+
+/**
+ * Adds visually-hidden text describing a feature's progress in text,
+ * so screen reader users don't need to navigate to the emoji key.
+ * @param {string} emoji an emoji corresponding to a feature progress status in the key
+ * @returns {string} HTML string containing a screen reader-friendly label
+ */
+module.exports = function convertEmojiToAccessibleProgress(emoji) {
+  // Emoji is not defined in the key
+  if (!EMOJI_KEY[emoji]) {
+    const validEmojis = Object.keys(EMOJI_KEY).join(', ')
+    console.warn(
+      `"${emoji}" is not in the feature progress emoji key yet. Valid emojis are ${validEmojis}. Consider adding ${emoji} to the key.`,
+    )
+    return emoji
+  }
+
+  const screenReaderNode = `<span class="sr-only"> ${EMOJI_KEY[emoji]}</span>`
+  return `${emoji}${screenReaderNode}`
+}


### PR DESCRIPTION
Howdy! This pull request is for the feature progress table in the docs. I love the emoji key you've got going on, but I noticed that screenreader users wouldn't be able to jump so easily between the emoji key and the table itself.

To make the experience a little easier for folks using assistive technology, I've introduced a `featureProgress` shortcode that takes the respective emoji and adds a visually-hidden node next to it with the full label from the emoji key — so instead of announcing the ⏳ emoji as just `hourglass`, for instance, screenreaders will announce it as something like `hourglass In progress`.

(I opted not to put an `aria-hidden` on the emojis, since leaving the emojis in would allow folks to still cross-reference the table with the emoji key below it)