### PR TITLE
Add aria-current to active page link in left-hand nav

### DIFF
--- a/www/src/_layouts/docs.njk
+++ b/www/src/_layouts/docs.njk
@@ -27,7 +27,6 @@ styles:
         <a
           href="{{navLink.href}}"
           {% if navLink.href === page.url %}aria-current="page"{% endif %}
-          class="{{'active' if navLink.href === page.url else ''}}"
         >
           {{navLink.title}}
         </a>

--- a/www/src/_layouts/docs.njk
+++ b/www/src/_layouts/docs.njk
@@ -24,7 +24,13 @@ styles:
     <ul class="docs__side-nav" role="list">
       {%- for navLink in navLinksSorted -%}
       <li>
-        <a href="{{navLink.href}}" class="{{'active' if navLink.href === page.url else ''}}">{{navLink.title}}</a>
+        <a
+          href="{{navLink.href}}"
+          {% if navLink.href === page.url %}aria-current="page"{% endif %}
+          class="{{'active' if navLink.href === page.url else ''}}"
+        >
+          {{navLink.title}}
+        </a>
       </li>
       {%- endfor -%}
     </ul>

--- a/www/styles/docs.scss
+++ b/www/styles/docs.scss
@@ -82,7 +82,7 @@
       color: var(--white);
       position: relative;
   
-      &.active {
+      &[aria-current="page"] {
         color: var(--color-accent-4);
 
         &::before {


### PR DESCRIPTION
Here's another accessibility one for you! This one applies `aria-current="page"` to whichever link in the left-hand navbar is the current page. This means that when screenreader users navigate to that link within the navbar, they'll hear something like "Configure your project, link, current" (exact announcement varies amongst screenreaders).

This is basically the screenreader equivalent of your `.active` class for sighted users. On that note, some folks like to target `[aria-current="true"]` for styles instead of an `.active` class to better enforce semantics/accessibility. I haven't done that here, but I'd be happy to do that too if that's something you'd be interested in.