### PR TITLE
Use <header> element on homepage

### DIFF
--- a/www/src/_layouts/home.njk
+++ b/www/src/_layouts/home.njk
@@ -4,7 +4,7 @@ styles:
   - '/@root/styles/home.scss'
 ---
 
-<section class="home__heading">
+<header class="home__heading">
   <div class="home__banner-container">
     {% include 'logo.njk' %}
   </div>
@@ -23,7 +23,7 @@ styles:
     <a class="home__heading-link" href="https://www.npmjs.com/package/slinkity">npm package</a>
     <a class="home__heading-link" href="https://github.com/slinkity/slinkity">Star on GitHub</a>
   </div>
-</section>
+</header>
 
 <main class="home__content">
   {{ content | safe }}


### PR DESCRIPTION
I ran an Axe DevTools scan on the slinkity.dev homepage. One issue it flagged was that "all content needed to be contained by landmark elements," and it said that the stuff in the top section — logo, tagline, blockquote, links — weren't in a landmark.

They were in a `<section>` element, which does become a landmark when labelled, but I felt like rather than try to come up with a good label, I'd replace that `<section>` with `<header>`, which describes the function of that piece of the page pretty well.