### PR TITLE
Updating heading order in the docs

### DIFF
--- a/www/src/docs/component-pages-layouts.md
+++ b/www/src/docs/component-pages-layouts.md
@@ -255,4 +255,4 @@ function getProps(eleventyData) {
 // -> { tenXEngineer: 10 }
 ```
 
-### [Learn the different ways to render components →](/docs/partial-hydration/)
+**[Learn the different ways to render components →](/docs/partial-hydration/)**

--- a/www/src/docs/component-shortcodes.md
+++ b/www/src/docs/component-shortcodes.md
@@ -56,7 +56,7 @@ To opt-out of shipping JS, you can render your component as "static" HTML and CS
 
 For a full list of options to fine-tune how and when JavaScript is loaded on the client...
 
-### [💧 Learn more about partial hydration →](/docs/partial-hydration)
+**[💧 Learn more about partial hydration →](/docs/partial-hydration)**
 
 ## Passing props to shortcodes
 
@@ -108,4 +108,4 @@ url=page.url, fileSlug=page.fileSlug %}{% endraw %}
 
 Injecting components into templates is nice... but what if we want to build the entire route using a component framework?
 
-### [Learn about page-level components →](/docs/component-pages-layouts)
+**[Learn about page-level components →](/docs/component-pages-layouts)**

--- a/www/src/docs/import-aliases.md
+++ b/www/src/docs/import-aliases.md
@@ -20,7 +20,7 @@ And HTML files:
 </head>
 ```
 
-### List of aliases
+## List of aliases
 
 - **/@root** - Relative to the base of your project. No, this is _not_ your project's input directory! This is merely based on where you ran the `slinkity` CLI command from. This is often used for `assets` or `utils` that wouldn't make sense as `input` directory routes or `_includes` entries.
 - **/@input** - Relative to your project's input directory, as configured using the `--input` CLI flag or 11ty's `dir` config option (see [our config docs](/docs/config) for more details)

--- a/www/src/docs/index.md
+++ b/www/src/docs/index.md
@@ -19,7 +19,7 @@ Slinkity stands on the shoulders of giants. You can think of Slinkity as the "gl
 
 To learn more, and explore adding Slinkity to _existing_ 11ty projects...
 
-### [🐣 See our "quick start" guide →](/docs/quick-start)
+[🐣 See our "quick start" guide →](/docs/quick-start)
 
 ## Feature set
 

--- a/www/src/docs/index.md
+++ b/www/src/docs/index.md
@@ -4,7 +4,7 @@ title: What is Slinkity?
 
 {% include 'value-props.md' %}
 
-### [📣 Find our full announcement post here →](/)
+**[📣 Find our full announcement post here →](/)**
 
 ## Technologies used
 
@@ -19,7 +19,7 @@ Slinkity stands on the shoulders of giants. You can think of Slinkity as the "gl
 
 To learn more, and explore adding Slinkity to _existing_ 11ty projects...
 
-[🐣 See our "quick start" guide →](/docs/quick-start)
+**[🐣 See our "quick start" guide →](/docs/quick-start)**
 
 ## Feature set
 

--- a/www/src/docs/quick-start.md
+++ b/www/src/docs/quick-start.md
@@ -124,4 +124,4 @@ This will do a few things:
 
 Now in your browser preview, clicking "Add one" should increase your counter 🎉
 
-### [Learn more about component shortcodes →](/docs/component-shortcodes)
+**[Learn more about component shortcodes →](/docs/component-shortcodes)**

--- a/www/styles/docs.scss
+++ b/www/styles/docs.scss
@@ -157,7 +157,7 @@
 
       :where(p > strong:only-child > a:only-child) {
         font-size: 1.17em;
-	  }
+      }
 
       :where(table) {
         background-color: var(--color-primary-7);

--- a/www/styles/docs.scss
+++ b/www/styles/docs.scss
@@ -157,7 +157,6 @@
 
       :where(p > strong:only-child > a:only-child) {
         font-size: 1.17em;
-        font-weight: bold;
 	  }
 
       :where(table) {

--- a/www/styles/docs.scss
+++ b/www/styles/docs.scss
@@ -155,6 +155,12 @@
         }
       }
 
+      :where(p > a:only-child),
+      :where(p > strong:only-child > a:only-child) {
+        font-size: 1.17em;
+        font-weight: bold;
+	  }
+
       :where(table) {
         background-color: var(--color-primary-7);
         width: 100%;

--- a/www/styles/docs.scss
+++ b/www/styles/docs.scss
@@ -155,7 +155,6 @@
         }
       }
 
-      :where(p > a:only-child),
       :where(p > strong:only-child > a:only-child) {
         font-size: 1.17em;
         font-weight: bold;


### PR DESCRIPTION
Axe DevTools picked up that the Slinkity docs had some heading levels out of order. For the most part, this was due to `<h3>`s being used to make certain links look more prominent, rather than to section up the page.

This PR introduces some styles to help make those links just as prominent without using `h3` (and - as a bonus! - without straying from Markdown syntax!). To use these styles put your link in a new line, wrapped in a `<strong>` tag, and make sure there's nothing else on that line. For instance:

```md
...previous paragraph ending here.

**[🐣 See our "quick start" guide →](/docs/quick-start)**

Next paragraph starts here...
```

The link above will be bolded and the same font size as an `h3`.