### PR TITLE
Ensure codeblocks are tabbable

### DIFF
--- a/www/.eleventy.js
+++ b/www/.eleventy.js
@@ -39,7 +39,7 @@ module.exports = function config(eleventyConfig) {
     {
       preAttributes: {
         tabindex: 0
-	  }
+      }
     }
   )
 

--- a/www/.eleventy.js
+++ b/www/.eleventy.js
@@ -34,7 +34,14 @@ module.exports = function config(eleventyConfig) {
   eleventyConfig.setLibrary('md', markdownConfigured)
   eleventyConfig.addPassthroughCopy('public')
   eleventyConfig.addDataExtension('yaml', (contents) => yaml.load(contents))
-  eleventyConfig.addPlugin(syntaxHighlight)
+  eleventyConfig.addPlugin(
+    syntaxHighlight,
+    {
+      preAttributes: {
+        tabindex: 0
+	  }
+    }
+  )
 
   return {
     htmlTemplateEngine: 'njk',

--- a/www/styles/_base.scss
+++ b/www/styles/_base.scss
@@ -18,6 +18,10 @@ body {
         text-shadow: 0 0 4px var(--color-primary-4);
         box-decoration-break: clone;
         -webkit-box-decoration-break: clone;
+
+        &:focus {
+            box-shadow: 0px 4px 14px var(--color-accent-4);
+		}
     }
 }
 

--- a/www/styles/_base.scss
+++ b/www/styles/_base.scss
@@ -21,7 +21,7 @@ body {
 
         &:focus {
             box-shadow: 0px 4px 14px var(--color-accent-4);
-		}
+        }
     }
 }
 


### PR DESCRIPTION
When containers such as codeblocks are scrollable, it's generally a good practice to make sure they're tabbable with the keyboard — that way, keyboard navigators can use their arrow keys to scroll left and right.

This PR applies `tabindex="0"` to all `<pre>` tags on the site to make them tabbable, and gives them pink glowy focus styles when they are tabbed.