### PR TITLE
Accessibility for contributors table

### DIFF
--- a/www/src/_includes/contributors.njk
+++ b/www/src/_includes/contributors.njk
@@ -2,8 +2,19 @@
   {% for contributor in contributors %}
   <article class="contributor">
     <img class="contributor__image" src="{{contributor.imageUrl}}" alt="{{contributor.username}}">
-    <h4 class="contributor__username"><a href=" {{contributor.url}}">{{contributor.username}}</a></h4>
-    <p class="contributor__title">{{contributor.title}}</p>
+    <a
+      href="{{contributor.url}}"
+      class="contributor__username"
+      aria-describedby="{{contributor.username}}-title"
+    >
+      {{contributor.username}}
+    </a>
+    <p
+      id="{{contributor.username}}-title"
+      class="contributor__title"
+    >
+      {{contributor.title}}
+    </p>
   </article>
   {% endfor %}
 </div>

--- a/www/styles/chunks/_contributor.scss
+++ b/www/styles/chunks/_contributor.scss
@@ -24,13 +24,15 @@
     &__username {
         text-align: center;
         font-size: 1.17em;
+        display: block;
+        font-weight: bold;
+        margin-block-start: 1.33em;
+        margin-block-end: 1.33em;
 
-        & > a {
-            &::before {
-                content: '';
-                position: absolute;
-                inset: 0;
-            }
+        &::before {
+            content: '';
+            position: absolute;
+            inset: 0;
         }
     }
     


### PR DESCRIPTION
I noticed that the contributors table was using `<h4>` elements to give contributor usernames extra prominence. Since the `h4`s weren't being used for sectioning, I've removed the `h4`s around the username links and given the username links `display: block;`, `font-weight: bold`, and the appropriate margins to emulate the same appearance those links had inside an `h4`.

I've also added an `aria-describedby` on the username links, pointing to the contributor's title. This means that if someone is tabbing through the contributor links while using a screenreader, if they choose to _linger_ on a link, it will announce their title as supplementary information: `Holben888, link, Supreme Slinkity Stan`. More info at https://benmyers.dev/blog/aria-labels-and-descriptions/