### PR TITLE
Add utils.consts:toSSRComment unit test

### DIFF
--- a/packages/slinkity/utils/consts.js
+++ b/packages/slinkity/utils/consts.js
@@ -43,6 +43,12 @@ const SLINKITY_CONFIG_FILE_NAME = 'slinkity.config'
 
 const BUILD_HASH = uuidv4()
 
+/**
+ * Returns an SSR comment with build hash and ID.
+ *
+ * @param  {string} id ID.
+ * @return {string}    SSR comment.
+ */
 function toSSRComment(id) {
   return `<!--slinkity-ssr ${BUILD_HASH} ${id}-->`
 }

--- a/packages/slinkity/utils/consts.test.js
+++ b/packages/slinkity/utils/consts.test.js
@@ -4,7 +4,7 @@ describe('toSSRComment', () => {
   it('should return an SSR comment with build hash and ID', () => {
     const id = 'some-id'
     const expected = expect.stringMatching(
-      /<!--slinkity-ssr [a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12} some-id-->/,
+      /<!--slinkity-ssr [a-z0-9]{8}(-[a-z0-9]{4}){3}-[a-z0-9]{12} some-id-->/,
     )
 
     expect(toSSRComment(id)).toEqual(expected)

--- a/packages/slinkity/utils/consts.test.js
+++ b/packages/slinkity/utils/consts.test.js
@@ -1,0 +1,12 @@
+const { toSSRComment } = require('./consts')
+
+describe('toSSRComment', () => {
+  it('should return an SSR comment with build hash and ID', () => {
+    const id = 'some-id'
+    const expected = expect.stringMatching(
+      /<!--slinkity-ssr [a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12} some-id-->/,
+    )
+
+    expect(toSSRComment(id)).toEqual(expected)
+  })
+})


### PR DESCRIPTION
## Summary
Adds a simple passing unit test for `utils/consts:toSSRComment`.

## Testing
- [x] `npm run build:slinkity`
- [x] `npm test`
- [x] `npm run lint`

## Ticket
 Unit test core functionality #21 

## Screenshot
<img width="550" alt="Successful build results" src="https://user-images.githubusercontent.com/7530507/149680733-8e6dd0ce-c554-43b3-b468-e908b6a99121.png">

<img width="535" alt="Results of unit tests and linting with all tests passing and no lint errors" src="https://user-images.githubusercontent.com/7530507/149679626-eda8e173-7c8f-4a68-a62c-6d3b813b8f5f.png">