### PR TITLE
[#21] Validate ID passed to toSSRComment

### DIFF
--- a/packages/slinkity/utils/consts.js
+++ b/packages/slinkity/utils/consts.js
@@ -46,10 +46,14 @@ const BUILD_HASH = uuidv4()
 /**
  * Returns an SSR comment with build hash and ID.
  *
- * @param  {string} id ID.
+ * @param  {string} id (required) ID.
  * @return {string}    SSR comment.
  */
 function toSSRComment(id) {
+  if (typeof id !== 'string' || id === '') {
+    throw new TypeError('must pass non-empty string to toSSRComment')
+  }
+
   return `<!--slinkity-ssr ${BUILD_HASH} ${id}-->`
 }
 

--- a/packages/slinkity/utils/consts.test.js
+++ b/packages/slinkity/utils/consts.test.js
@@ -1,9 +1,13 @@
 const { toSSRComment } = require('./consts')
 
 describe('toSSRComment', () => {
-  it('should throw an error if missing an ID', () => {
+  it('should throw without a valid ID', () => {
     const message = 'must pass non-empty string to toSSRComment'
     expect(() => toSSRComment()).toThrowError(new TypeError(message))
+    expect(() => toSSRComment('')).toThrowError(new TypeError(message))
+    expect(() => toSSRComment(123)).toThrowError(new TypeError(message))
+    expect(() => toSSRComment(['some-id'])).toThrowError(new TypeError(message))
+    expect(() => toSSRComment({})).toThrowError(new TypeError(message))
   })
 
   it('should return an SSR comment with build hash and ID', () => {

--- a/packages/slinkity/utils/consts.test.js
+++ b/packages/slinkity/utils/consts.test.js
@@ -1,6 +1,11 @@
 const { toSSRComment } = require('./consts')
 
 describe('toSSRComment', () => {
+  it('should throw an error if missing an ID', () => {
+    const message = 'must pass non-empty string to toSSRComment'
+    expect(() => toSSRComment()).toThrowError(new TypeError(message))
+  })
+
   it('should return an SSR comment with build hash and ID', () => {
     const id = 'some-id'
     const expected = expect.stringMatching(


### PR DESCRIPTION
## Summary
Following up #136, this adds one more unit test for validating the `id` param passed to `toSSRComment`. The function itself will now throw a `TypeError` if called without a valid `id`.

I confirmed that `toSSRComment` is not called anywhere in the codebase without a valid `id`. This change adds a layer of validation against future development work that might use this function--the `TypeError` would be thrown in the console during development if the function was called without a valid ID.

## Testing
- [x] `npm run build:slinkity`
- [x] `npm test`
- [x] `npm run lint`

## Ticket
 Unit test core functionality #21 

## Screenshot
<img width="684" alt="Successful build, test, and lint results" src="https://user-images.githubusercontent.com/7530507/149777743-57bc1a4f-b61a-40f0-a550-02ed76d54781.png">
