### PR TITLE
Add resolveConfigFilePath unit tests

### DIFF
--- a/packages/slinkity/utils/resolveConfigFilePath.test.js
+++ b/packages/slinkity/utils/resolveConfigFilePath.test.js
@@ -1,0 +1,21 @@
+const { resolveConfigFilePath } = require('./resolveConfigFilePath')
+const { resolve } = require('path')
+
+describe('resolveConfigFilePath', () => {
+  it('returns undefined if no file is found', async () => {
+    expect(await resolveConfigFilePath([])).toBeUndefined()
+    expect(await resolveConfigFilePath(['path/to/nothing'])).toBeUndefined()
+  })
+
+  it('returns the first found file path', async () => {
+    expect(await resolveConfigFilePath(['README.md'])).toBe(resolve('README.md'))
+    expect(
+      await resolveConfigFilePath([
+        'path/to/nothing',
+        'README.md',
+        'package.json',
+        'another/path/to/nothing',
+      ]),
+    ).toBe(resolve('README.md'))
+  })
+})


### PR DESCRIPTION
## Summary
This adds a couple unit tests for `resolveConfigFilePath`.

## Testing
- [x] `npm run build:slinkity`
- [x] `npm test`
- [x] `npm run lint`

## Ticket
 Unit test core functionality #21

## Screenshot
<img width="846" alt="Screenshot of successful build, passing unit tests with coverage report, and successful linting without errors" src="https://user-images.githubusercontent.com/7530507/149834451-d43d4cfd-319c-4e6f-8744-28a18dce52e3.png">