### PR TITLE
Add cli/vite unit tests

### DIFF
--- a/packages/slinkity/cli/vite.js
+++ b/packages/slinkity/cli/vite.js
@@ -5,11 +5,18 @@ const glob = promisify(require('glob'))
 const { resolveConfigFilePath } = require('../utils/resolveConfigFilePath')
 const { IMPORT_ALIASES } = require('../utils/consts')
 
+/**
+ * Returns config file path or undefined if config file does not exist.
+ *
+ * @return {string|undefined} File path.
+ */
 function getConfigFile() {
   return resolveConfigFilePath(['js', 'mjs', 'ts'].map((ext) => `vite.config.${ext}`))
 }
 
 /**
+ * Returns object with resolved aliases.
+ *
  * @typedef {import('../utils/consts').ImportAliases} ImportAliases
  * @typedef {Record<keyof import('../utils/consts').ImportAliases, string>} ResolvedImportAliases
  * @param {import('../eleventyConfig/index').SlinkityConfigOptions['dir']} dir

--- a/packages/slinkity/cli/vite.test.js
+++ b/packages/slinkity/cli/vite.test.js
@@ -2,34 +2,38 @@ const { getConfigFile, getResolvedAliases } = require('./vite')
 const { resolve } = require('path')
 
 describe('vite', () => {
-  it('getConfigFile', async () => {
-    expect(await getConfigFile()).toBeUndefined()
+  describe('getConfigFile', () => {
+    it('returns undefined when vite config file does not exist', async () => {
+      expect(await getConfigFile()).toBeUndefined()
+    })
   })
 
-  it('getResolvedAliases', () => {
-    const empty = {
-      input: '',
-      includes: '',
-      layouts: '',
-    }
-    const emptyExpected = {
-      root: resolve(''),
-      input: resolve(''),
-      includes: resolve(''),
-      layouts: resolve(''),
-    }
-    const config = {
-      input: 'input',
-      includes: 'includes',
-      layouts: 'layouts',
-    }
-    const configExpected = {
-      root: resolve(''),
-      input: resolve(config.input),
-      includes: resolve(config.input, config.includes),
-      layouts: resolve(config.input, config.layouts),
-    }
-    expect(getResolvedAliases(empty)).toStrictEqual(emptyExpected)
-    expect(getResolvedAliases(config)).toStrictEqual(configExpected)
+  describe('getResolvedAliases', () => {
+    it('returns object with resolved aliases', () => {
+      const empty = {
+        input: '',
+        includes: '',
+        layouts: '',
+      }
+      const emptyExpected = {
+        root: resolve(''),
+        input: resolve(''),
+        includes: resolve(''),
+        layouts: resolve(''),
+      }
+      const config = {
+        input: 'input',
+        includes: 'includes',
+        layouts: 'layouts',
+      }
+      const configExpected = {
+        root: resolve(''),
+        input: resolve(config.input),
+        includes: resolve(config.input, config.includes),
+        layouts: resolve(config.input, config.layouts),
+      }
+      expect(getResolvedAliases(empty)).toStrictEqual(emptyExpected)
+      expect(getResolvedAliases(config)).toStrictEqual(configExpected)
+    })
   })
 })

--- a/packages/slinkity/cli/vite.test.js
+++ b/packages/slinkity/cli/vite.test.js
@@ -1,0 +1,35 @@
+const { getConfigFile, getResolvedAliases } = require('./vite')
+const { resolve } = require('path')
+
+describe('vite', () => {
+  it('getConfigFile', async () => {
+    expect(await getConfigFile()).toBeUndefined()
+  })
+
+  it('getResolvedAliases', () => {
+    const empty = {
+      input: '',
+      includes: '',
+      layouts: '',
+    }
+    const emptyExpected = {
+      root: resolve(''),
+      input: resolve(''),
+      includes: resolve(''),
+      layouts: resolve(''),
+    }
+    const config = {
+      input: 'input',
+      includes: 'includes',
+      layouts: 'layouts',
+    }
+    const configExpected = {
+      root: resolve(''),
+      input: resolve(config.input),
+      includes: resolve(config.input, config.includes),
+      layouts: resolve(config.input, config.layouts),
+    }
+    expect(getResolvedAliases(empty)).toStrictEqual(emptyExpected)
+    expect(getResolvedAliases(config)).toStrictEqual(configExpected)
+  })
+})


### PR DESCRIPTION
## Summary
This adds passing unit tests for `cli/vite`.

## Testing
- [x] `npm run build:slinkity`
- [x] `npm test`
- [x] `npm run lint`

## Ticket
Unit test core functionality #21 

## Screenshot
<img width="754" alt="Screenshot of successful build, test, and lint results" src="https://user-images.githubusercontent.com/7530507/149838562-f33cafd5-c24a-4f48-80d1-6b44b18f403b.png">
