### PR TITLE
Feat: add Vue renderer

### DIFF
--- a/packages/slinkity-renderer-react/package-lock.json
+++ b/packages/slinkity-renderer-react/package-lock.json
@@ -7,12 +7,14 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -20,12 +22,14 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "react": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -35,6 +39,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -45,6 +50,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
       "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/packages/slinkity-renderer-react/package.json
+++ b/packages/slinkity-renderer-react/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "files": [
     "client.js",
-    "server.js"
+    "server.js",
+    "StaticHtml.js"
   ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
@@ -14,11 +15,15 @@
   "keywords": [],
   "author": "bholmesdev",
   "license": "ISC",
-  "dependencies": {
+  "peerDependencies": {
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "slinkity": "^0.5.0"
+  },
+  "devDependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
-  "devDependencies": {},
   "repository": {
     "type": "git",
     "url": "https://github.com/slinkity"

--- a/packages/slinkity-renderer-vue/StaticHtml.js
+++ b/packages/slinkity-renderer-vue/StaticHtml.js
@@ -1,0 +1,30 @@
+// TODO: use this once shortcode children are supported
+// Yes, this is copy / pasted from the Astro repo for now
+// Source: https://github.com/withastro/astro/blob/main/packages/renderers/renderer-vue/static-html.js
+import { h, defineComponent } from 'vue'
+
+/**
+ * Astro passes `children` as a string of HTML, so we need
+ * a wrapper `div` to render that content as VNodes.
+ *
+ * This is the Vue + JSX equivalent of using `<div v-html="value" />`
+ */
+const StaticHtml = defineComponent({
+  props: {
+    value: String,
+  },
+  setup({ value }) {
+    if (!value) return () => null
+    return () => h('astro-fragment', { innerHTML: value })
+  },
+})
+
+/**
+ * Other frameworks have `shouldComponentUpdate` in order to signal
+ * that this subtree is entirely static and will not be updated
+ *
+ * Fortunately, Vue is smart enough to figure that out without any
+ * help from us, so this just works out of the box!
+ */
+
+export default StaticHtml

--- a/packages/slinkity-renderer-vue/client.js
+++ b/packages/slinkity-renderer-vue/client.js
@@ -1,0 +1,14 @@
+import { h, createSSRApp } from 'vue'
+import StaticHtml from './StaticHtml'
+
+export default function client({ Component, target, props, children }) {
+  delete props['class']
+  // Expose name on host component for Vue devtools
+  const name = Component.name ? `${Component.name} Host` : undefined
+  const slots = {}
+  if (children != null) {
+    slots.default = () => h(StaticHtml, { value: children })
+  }
+  const app = createSSRApp({ name, render: () => h(Component, props, slots) })
+  app.mount(target, true)
+}

--- a/packages/slinkity-renderer-vue/index.js
+++ b/packages/slinkity-renderer-vue/index.js
@@ -1,0 +1,36 @@
+const { join } = require('path')
+const packageMeta = require('./package.json')
+const vue = require('@vitejs/plugin-vue')
+
+const client = join(packageMeta.name, 'client')
+const server = join(packageMeta.name, 'server')
+
+/** @type {import('../slinkity').Renderer} */
+module.exports = {
+  name: 'vue',
+  extensions: ['vue'],
+  client,
+  server,
+  injectImportedStyles: true,
+  viteConfig() {
+    return {
+      optimizeDeps: {
+        include: [client, 'vue'],
+        exclude: [server],
+      },
+      plugins: [vue()],
+      ssr: {
+        external: ['@vue/server-renderer'],
+      },
+    }
+  },
+  page({ toCommonJSModule }) {
+    return {
+      useFormatted11tyData: true,
+      async getData(inputPath) {
+        const { default: Component } = await toCommonJSModule(inputPath)
+        return Component.frontMatter
+      },
+    }
+  },
+}

--- a/packages/slinkity-renderer-vue/package-lock.json
+++ b/packages/slinkity-renderer-vue/package-lock.json
@@ -1,0 +1,203 @@
+{
+  "name": "@slinkity/renderer-vue",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/parser": {
+      "version": "7.16.12",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.12.tgz",
+      "integrity": "sha512-VfaV15po8RiZssrkPweyvbGVSe4x2y+aciFCgn0n0/SJMR22cwofRV1mtnJQYcSB1wUTaA/X1LnA3es66MCO5A==",
+      "dev": true
+    },
+    "@vitejs/plugin-vue": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-1.10.2.tgz",
+      "integrity": "sha512-/QJ0Z9qfhAFtKRY+r57ziY4BSbGUTGsPRMpB/Ron3QPwBZM4OZAZHdTa4a8PafCwU5DTatXG8TMDoP8z+oDqJw=="
+    },
+    "@vue/compiler-core": {
+      "version": "3.2.28",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.28.tgz",
+      "integrity": "sha512-mQpfEjmHVxmWKaup0HL6tLMv2HqjjJu7XT4/q0IoUXYXC4xKG8lIVn5YChJqxBTLPuQjzas7u7i9L4PAWJZRtA==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.16.4",
+        "@vue/shared": "3.2.28",
+        "estree-walker": "^2.0.2",
+        "source-map": "^0.6.1"
+      }
+    },
+    "@vue/compiler-dom": {
+      "version": "3.2.28",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.28.tgz",
+      "integrity": "sha512-KA4yXceLteKC7VykvPnViUixemQw3A+oii+deSbZJOQKQKVh1HLosI10qxa8ImPCyun41+wG3uGR+tW7eu1W6Q==",
+      "dev": true,
+      "requires": {
+        "@vue/compiler-core": "3.2.28",
+        "@vue/shared": "3.2.28"
+      }
+    },
+    "@vue/compiler-sfc": {
+      "version": "3.2.28",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.28.tgz",
+      "integrity": "sha512-zB0WznfEBb4CbGBHzhboHDKVO5nxbkbxxFo9iVlxObP7a9/qvA5kkZEuT7nXP52f3b3qEfmVTjIT23Lo1ndZdQ==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.16.4",
+        "@vue/compiler-core": "3.2.28",
+        "@vue/compiler-dom": "3.2.28",
+        "@vue/compiler-ssr": "3.2.28",
+        "@vue/reactivity-transform": "3.2.28",
+        "@vue/shared": "3.2.28",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.25.7",
+        "postcss": "^8.1.10",
+        "source-map": "^0.6.1"
+      }
+    },
+    "@vue/compiler-ssr": {
+      "version": "3.2.28",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.28.tgz",
+      "integrity": "sha512-z8rck1PDTu20iLyip9lAvIhaO40DUJrw3Zv0mS4Apfh3PlfWpF5dhsO5g0dgt213wgYsQIYVIlU9cfrYapqRgg==",
+      "dev": true,
+      "requires": {
+        "@vue/compiler-dom": "3.2.28",
+        "@vue/shared": "3.2.28"
+      }
+    },
+    "@vue/reactivity": {
+      "version": "3.2.28",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.28.tgz",
+      "integrity": "sha512-WamM5LGv7JIarW+EYAzYFqYonZXjTnOjNW0sBO93jRE9I1ReAwfH8NvQXkPA3JZ3fuF6SGDdG8Y9/+dKjd/1Gw==",
+      "dev": true,
+      "requires": {
+        "@vue/shared": "3.2.28"
+      }
+    },
+    "@vue/reactivity-transform": {
+      "version": "3.2.28",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.28.tgz",
+      "integrity": "sha512-zE8idNkOPnBDd2tKSIk84hOQZ+jXKvSy5FoIIVlcNEJHnCFnQ3maqeSJ9KoB2Rf6EXUhFTiTDNRlYlXmT2uHbQ==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.16.4",
+        "@vue/compiler-core": "3.2.28",
+        "@vue/shared": "3.2.28",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.25.7"
+      }
+    },
+    "@vue/runtime-core": {
+      "version": "3.2.28",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.28.tgz",
+      "integrity": "sha512-sVbBMFUt42JatTlXbdH6tVcLPw1eEOrrVQWI+j6/nJVzR852RURaT6DhdR0azdYscxq4xmmBctE0VQmlibBOFw==",
+      "dev": true,
+      "requires": {
+        "@vue/reactivity": "3.2.28",
+        "@vue/shared": "3.2.28"
+      }
+    },
+    "@vue/runtime-dom": {
+      "version": "3.2.28",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.28.tgz",
+      "integrity": "sha512-Jg7cxZanEXXGu1QnZILFLnDrM+MIFN8VAullmMZiJEZziHvhygRMpi0ahNy/8OqGwtTze1JNhLdHRBO+q2hbmg==",
+      "dev": true,
+      "requires": {
+        "@vue/runtime-core": "3.2.28",
+        "@vue/shared": "3.2.28",
+        "csstype": "^2.6.8"
+      }
+    },
+    "@vue/server-renderer": {
+      "version": "3.2.28",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.28.tgz",
+      "integrity": "sha512-S+MhurgkPabRvhdDl8R6efKBmniJqBbbWIYTXADaJIKFLFLQCW4gcYUTbxuebzk6j3z485vpekhrHHymTF52Pg==",
+      "dev": true,
+      "requires": {
+        "@vue/compiler-ssr": "3.2.28",
+        "@vue/shared": "3.2.28"
+      }
+    },
+    "@vue/shared": {
+      "version": "3.2.28",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.28.tgz",
+      "integrity": "sha512-eMQ8s9j8FpbGHlgUAaj/coaG3Q8YtMsoWL/RIHTsE3Ex7PUTyr7V91vB5HqWB5Sn8m4RXTHGO22/skoTUYvp0A==",
+      "dev": true
+    },
+    "csstype": {
+      "version": "2.6.19",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
+      "integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==",
+      "dev": true
+    },
+    "estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
+    "magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
+    "nanoid": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
+      "dev": true
+    },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
+    "postcss": {
+      "version": "8.4.5",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
+      "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
+      "dev": true,
+      "requires": {
+        "nanoid": "^3.1.30",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.1"
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
+    },
+    "vue": {
+      "version": "3.2.28",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.28.tgz",
+      "integrity": "sha512-U+jBwVh3RQ9AgceLFdT7i2FFujoC+kYuGrKo5y8aLluWKZWPS40WgA2pyYHaiSX9ydCbEGr3rc/JzdqskzD95g==",
+      "dev": true,
+      "requires": {
+        "@vue/compiler-dom": "3.2.28",
+        "@vue/compiler-sfc": "3.2.28",
+        "@vue/runtime-dom": "3.2.28",
+        "@vue/server-renderer": "3.2.28",
+        "@vue/shared": "3.2.28"
+      }
+    }
+  }
+}

--- a/packages/slinkity-renderer-vue/package.json
+++ b/packages/slinkity-renderer-vue/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@slinkity/renderer-vue",
+  "version": "0.0.1",
+  "description": "Vue component renderer for the legendary 11ty tool, Slinkity",
+  "main": "index.js",
+  "files": [
+    "client.js",
+    "server.js",
+    "StaticHtml.js"
+  ],
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "bholmesdev",
+  "license": "ISC",
+  "dependencies": {
+    "@vitejs/plugin-vue": "^1.10.2"
+  },
+  "devDependencies": {
+    "vue": "^3.2.28"
+  },
+  "peerDependencies": {
+    "slinkity": "^0.5.0",
+    "vue": "^3.2.28"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/slinkity",
+    "directory": "packages/slinkity-renderer-vue"
+  }
+}

--- a/packages/slinkity-renderer-vue/server.js
+++ b/packages/slinkity-renderer-vue/server.js
@@ -1,0 +1,14 @@
+import { h, createSSRApp } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import StaticHtml from './StaticHtml'
+
+export default async function server({ toCommonJSModule, componentPath, props, children }) {
+  const { default: Component } = await toCommonJSModule(componentPath)
+  const slots = {}
+  if (children) {
+    slots.default = () => h(StaticHtml, { value: children })
+  }
+  const app = createSSRApp({ render: () => h(Component, props, slots) })
+  const html = await renderToString(app)
+  return { html }
+}

--- a/packages/slinkity/eleventyConfig/__snapshots__/applyViteHtmlTransform.test.js.snap
+++ b/packages/slinkity/eleventyConfig/__snapshots__/applyViteHtmlTransform.test.js.snap
@@ -23,10 +23,8 @@ exports[`applyViteHtmlTransform handleSSRComments should replace SSR comments wi
   <title>It's hydration time</title>
 </head>
 <body>
-  <slinkity-react-mount-point data-s-id=\\"0\\">
-	<react>Content</react>
-  <p>rendered by react</p>
-</slinkity-react-mount-point>
+  <slinkity-react-mount-point data-s-id=\\"0\\"><react>Content</react>
+  <p>rendered by react</p></slinkity-react-mount-point>
 <script type=\\"module\\">
     import Component0 from \\"nice.jsx\\";
     import renderer0 from \\"@slinkity/example/client\\";
@@ -39,10 +37,8 @@ exports[`applyViteHtmlTransform handleSSRComments should replace SSR comments wi
       props: {},
     });
   </script>
-<slinkity-react-mount-point data-s-id=\\"1\\">
-	<svelte>Content</svelte>
-  <p>rendered by svelte</p>
-</slinkity-react-mount-point>
+<slinkity-react-mount-point data-s-id=\\"1\\"><svelte>Content</svelte>
+  <p>rendered by svelte</p></slinkity-react-mount-point>
 <script type=\\"module\\">
     import Component1 from \\"cool.svelte\\";
     import renderer1 from \\"@slinkity/svelte/client\\";
@@ -55,10 +51,8 @@ exports[`applyViteHtmlTransform handleSSRComments should replace SSR comments wi
       props: {},
     });
   </script>
-<slinkity-react-mount-point data-s-id=\\"2\\">
-	<vue>Content</vue>
-  <p>rendered by vue</p>
-</slinkity-react-mount-point>
+<slinkity-react-mount-point data-s-id=\\"2\\"><vue>Content</vue>
+  <p>rendered by vue</p></slinkity-react-mount-point>
 <script type=\\"module\\">
     import Component2 from \\"neat.vue\\";
     import renderer2 from \\"@slinkity/vue/client\\";

--- a/packages/slinkity/eleventyConfig/addComponentShortcodes.js
+++ b/packages/slinkity/eleventyConfig/addComponentShortcodes.js
@@ -44,6 +44,8 @@ module.exports = function addShortcode({
       })
     }
 
+    delete props['__keywords']
+
     /** @type {{ hydrate: import('../cli/types').HydrationMode }} */
     const { hydrate = 'none' } = props
     const id = componentAttrStore.push({

--- a/packages/slinkity/eleventyConfig/applyViteHtmlTransform.js
+++ b/packages/slinkity/eleventyConfig/applyViteHtmlTransform.js
@@ -58,7 +58,7 @@ async function handleSSRComments({ content, outputPath, componentAttrStore, vite
       const clientRenderer = rendererMap[rendererName].client
       const loaderScript = toLoaderScript({ componentPath, props, hydrate, id, clientRenderer })
       const attrs = toHtmlAttrString({ [SLINKITY_ATTRS.id]: id })
-      return `<${SLINKITY_REACT_MOUNT_POINT} ${attrs}>\n\t${serverRenderedComponents[id]}\n</${SLINKITY_REACT_MOUNT_POINT}>\n${loaderScript}`
+      return `<${SLINKITY_REACT_MOUNT_POINT} ${attrs}>${serverRenderedComponents[id]}</${SLINKITY_REACT_MOUNT_POINT}>\n${loaderScript}`
     })
     // inject component styles into head
     .replace(


### PR DESCRIPTION
Resolves #12 🥳 

## Notable changes
- created a new `@slinkity/renderer-vue` package that's ready to publish
- fixed the `@slinkity/renderer-react` dependencies while I was at it! Discovered the combo of `peerDeps` and `devDeps` we need for framework-specific code from [Vite's Vue plugin](https://github.com/vitejs/vite/blob/main/packages/plugin-vue/package.json). Thought we should use that same pattern across the board going forward
- removed that `__keywords` prop from `addComponentShortcodes`. Seems that prop sneaks in on the `...vargs` spread. This prevents Vue warnings about unexpected props