### PR TITLE
Feat: support shortcodes in JSX templates

### DIFF
--- a/packages/slinkity-renderer-react/StaticHtml.js
+++ b/packages/slinkity-renderer-react/StaticHtml.js
@@ -13,10 +13,17 @@ import { createElement as h } from 'react'
  */
 const StaticHtml = ({ value }) => {
   if (!value) return null
-  return h('astro-fragment', {
+  return h('slinkity-fragment', {
     suppressHydrationWarning: true,
     dangerouslySetInnerHTML: { __html: value },
   })
+}
+
+export function toComponentByShortcode({ unnamedArgs, shortcode }) {
+  return (namedArgs) => {
+    const value = shortcode(...unnamedArgs, namedArgs)
+    return h(StaticHtml, { value })
+  }
 }
 
 /**

--- a/packages/slinkity-renderer-react/index.js
+++ b/packages/slinkity-renderer-react/index.js
@@ -3,6 +3,7 @@ const packageMeta = require('./package.json')
 
 const client = join(packageMeta.name, 'client')
 const server = join(packageMeta.name, 'server')
+const toComponentByShortcode = join(packageMeta.name, 'StaticHtml')
 
 /** @type {import('../slinkity').Renderer} */
 module.exports = {
@@ -10,6 +11,7 @@ module.exports = {
   extensions: ['jsx', 'tsx'],
   client,
   server,
+  toComponentByShortcode,
   injectImportedStyles: true,
   viteConfig() {
     return {

--- a/packages/slinkity-renderer-vue/StaticHtml.js
+++ b/packages/slinkity-renderer-vue/StaticHtml.js
@@ -21,6 +21,10 @@ const StaticHtml = defineComponent({
 
 export function toComponentByShortcode({ unnamedArgs, shortcode }) {
   return defineComponent({
+    props: {
+      hydrate: String,
+      // TODO: support any props
+    },
     setup(namedArgs) {
       if (!namedArgs) return () => null
       const innerHTML = shortcode(...unnamedArgs, namedArgs)

--- a/packages/slinkity-renderer-vue/StaticHtml.js
+++ b/packages/slinkity-renderer-vue/StaticHtml.js
@@ -15,9 +15,20 @@ const StaticHtml = defineComponent({
   },
   setup({ value }) {
     if (!value) return () => null
-    return () => h('astro-fragment', { innerHTML: value })
+    return () => h('slinkity-fragment', { innerHTML: value })
   },
 })
+
+export function toComponentByShortcode({ unnamedArgs, shortcode }) {
+  return defineComponent({
+    setup(namedArgs) {
+      if (!namedArgs) return () => null
+      const innerHTML = shortcode(...unnamedArgs, namedArgs)
+      console.log({ innerHTML, unnamedArgs, namedArgs })
+      return () => h('slinkity-fragment', { innerHTML })
+    },
+  })
+}
 
 /**
  * Other frameworks have `shouldComponentUpdate` in order to signal

--- a/packages/slinkity-renderer-vue/index.js
+++ b/packages/slinkity-renderer-vue/index.js
@@ -4,6 +4,7 @@ const vue = require('@vitejs/plugin-vue')
 
 const client = join(packageMeta.name, 'client')
 const server = join(packageMeta.name, 'server')
+const toComponentByShortcode = join(packageMeta.name, 'StaticHtml')
 
 /** @type {import('../slinkity').Renderer} */
 module.exports = {
@@ -11,6 +12,7 @@ module.exports = {
   extensions: ['vue'],
   client,
   server,
+  toComponentByShortcode,
   injectImportedStyles: true,
   viteConfig() {
     return {

--- a/packages/slinkity-renderer-vue/server.js
+++ b/packages/slinkity-renderer-vue/server.js
@@ -8,7 +8,10 @@ export default async function server({ toCommonJSModule, componentPath, props, c
   if (children) {
     slots.default = () => h(StaticHtml, { value: children })
   }
-  const app = createSSRApp({ render: () => h(Component, props, slots) })
+  const shortcodes = Component.shortcodes?.(props.__slinkity?.shortcodes ?? {}) ?? {}
+  const app = createSSRApp({
+    render: () => h({ ...Component, components: shortcodes }, props, slots),
+  })
   const html = await renderToString(app)
   return { html }
 }

--- a/packages/slinkity/cli/types.d.ts
+++ b/packages/slinkity/cli/types.d.ts
@@ -53,6 +53,8 @@ export type Renderer = {
   client: string;
   /** path to module used for server rendering - NodeJS code */
   server: string;
+  /** path to module used to wrap shortcode HTML element in a component - NodeJS code */
+  toComponentByShortcode: string;
   /** inject CSS imported by component module into document head */
   injectImportedStyles: boolean;
   /** config to append to Vite server and production builds */

--- a/packages/slinkity/eleventyConfig/addComponentShortcodes.js
+++ b/packages/slinkity/eleventyConfig/addComponentShortcodes.js
@@ -44,14 +44,15 @@ module.exports = function addShortcode({
       })
     }
 
-    delete props['__keywords']
+    // eslint-disable-next-line no-unused-vars
+    const { __keywords, ...restOfProps } = props
 
     /** @type {{ hydrate: import('../cli/types').HydrationMode }} */
     const { hydrate = 'none' } = props
     const id = componentAttrStore.push({
       path: path.join(resolvedImportAliases.includes, componentPath),
       rendererName: renderer.name,
-      props,
+      props: restOfProps,
       hydrate,
       pageOutputPath: this.page.outputPath,
     })

--- a/packages/slinkity/eleventyConfig/applyViteHtmlTransform.js
+++ b/packages/slinkity/eleventyConfig/applyViteHtmlTransform.js
@@ -41,6 +41,23 @@ async function handleSSRComments({ content, outputPath, componentAttrStore, vite
       const { __importedStyles } = await viteSSR.toCommonJSModule(componentPath)
       __importedStyles.forEach((importedStyle) => importedStyles.add(importedStyle))
     }
+    let shortcodes = props.__slinkity?.shortcodes
+    if (typeof shortcodes === 'object' && hydrate === 'none') {
+      try {
+        const { toComponentByShortcode } = await viteSSR.toCommonJSModule(
+          renderer.toComponentByShortcode,
+        )
+        props.__slinkity.shortcodes = Object.fromEntries(
+          Object.entries(shortcodes).map(([name, shortcode]) => [
+            name,
+            (...unnamedArgs) => toComponentByShortcode({ unnamedArgs, shortcode }),
+          ]),
+        )
+      } catch {
+        // This renderer can't handle shortcodes-as-components.
+        // Do nothing!
+      }
+    }
     const serverRendered = await serverRenderer({
       toCommonJSModule: viteSSR.toCommonJSModule,
       componentPath,

--- a/packages/slinkity/eleventyConfig/applyViteHtmlTransform.js
+++ b/packages/slinkity/eleventyConfig/applyViteHtmlTransform.js
@@ -24,12 +24,16 @@ const ssrRegex = RegExp(toSSRComment('([0-9]+)'), 'g')
  * @param {HandleSSRCommentsParams}
  * @returns {Promise<string>} - HTML with components SSR'd
  */
-async function handleSSRComments({ content, outputPath, componentAttrStore, viteSSR, renderers }) {
+async function handleSSRComments({
+  content,
+  outputPath,
+  componentAttrStore,
+  viteSSR,
+  renderers,
+  importedStyles = new Set(),
+}) {
   /** @type {Record<string, any>} */
   const rendererMap = Object.fromEntries(renderers.map((renderer) => [renderer.name, renderer]))
-
-  /** @type {Set<string>} */
-  const importedStyles = new Set()
 
   const pageComponentAttrs = componentAttrStore.getAllByPage(outputPath)
   const serverRenderedComponents = []
@@ -42,17 +46,24 @@ async function handleSSRComments({ content, outputPath, componentAttrStore, vite
       __importedStyles.forEach((importedStyle) => importedStyles.add(importedStyle))
     }
     let shortcodes = props.__slinkity?.shortcodes
+    let propsWithShortcodes = props
     if (typeof shortcodes === 'object' && hydrate === 'none') {
       try {
         const { toComponentByShortcode } = await viteSSR.toCommonJSModule(
           renderer.toComponentByShortcode,
         )
-        props.__slinkity.shortcodes = Object.fromEntries(
-          Object.entries(shortcodes).map(([name, shortcode]) => [
-            name,
-            (...unnamedArgs) => toComponentByShortcode({ unnamedArgs, shortcode }),
-          ]),
-        )
+        propsWithShortcodes = {
+          ...props,
+          __slinkity: {
+            ...(props.__slinkity ?? {}),
+            shortcodes: Object.fromEntries(
+              Object.entries(shortcodes).map(([name, shortcode]) => [
+                name,
+                (...unnamedArgs) => toComponentByShortcode({ unnamedArgs, shortcode }),
+              ]),
+            ),
+          },
+        }
       } catch {
         // This renderer can't handle shortcodes-as-components.
         // Do nothing!
@@ -61,7 +72,7 @@ async function handleSSRComments({ content, outputPath, componentAttrStore, vite
     const serverRendered = await serverRenderer({
       toCommonJSModule: viteSSR.toCommonJSModule,
       componentPath,
-      props,
+      props: propsWithShortcodes,
       // TODO: add children to componentAttrStore
       children: '',
       hydrate,
@@ -78,24 +89,41 @@ async function handleSSRComments({ content, outputPath, componentAttrStore, vite
       const attrs = toHtmlAttrString({ [SLINKITY_ATTRS.id]: id })
       return `<${SLINKITY_REACT_MOUNT_POINT} ${attrs}>${serverRenderedComponents[id]}</${SLINKITY_REACT_MOUNT_POINT}>\n${loaderScript}`
     })
-    // inject component styles into head
-    .replace(
-      SLINKITY_HEAD_STYLES,
-      [...importedStyles]
-        .map((importedStyle) =>
-          importedStyle.endsWith('lang.css')
-            ? // lang.css is used by SFC (single file component) styles
-              // ex. <style scoped> in a .vue file
-              // these are sadly *not* supported by <link> tag imports,
-              // so we'll switch to <script> as a compromise
-              // Note: this does cause FOUC
-              // See this issue log for more details: https://github.com/slinkity/slinkity/issues/84#issuecomment-1003783754
-              `<script ${toHtmlAttrString({ type: 'module', src: importedStyle })}></script>`
-            : `<link ${toHtmlAttrString({ rel: 'stylesheet', href: importedStyle })}>`,
+
+  if (html.match(ssrRegex)) {
+    // if there's more SSR components, there are likely
+    // components rendered by other components using shortcodes.
+    // recursively render until all SSR comments are resolved.
+    return handleSSRComments({
+      content: html,
+      outputPath,
+      componentAttrStore,
+      viteSSR,
+      renderers,
+      importedStyles,
+    })
+  } else {
+    return (
+      html
+        // inject component styles into head
+        .replace(
+          SLINKITY_HEAD_STYLES,
+          [...importedStyles]
+            .map((importedStyle) =>
+              importedStyle.endsWith('lang.css')
+                ? // lang.css is used by SFC (single file component) styles
+                  // ex. <style scoped> in a .vue file
+                  // these are sadly *not* supported by <link> tag imports,
+                  // so we'll switch to <script> as a compromise
+                  // Note: this does cause FOUC
+                  // See this issue log for more details: https://github.com/slinkity/slinkity/issues/84#issuecomment-1003783754
+                  `<script ${toHtmlAttrString({ type: 'module', src: importedStyle })}></script>`
+                : `<link ${toHtmlAttrString({ rel: 'stylesheet', href: importedStyle })}>`,
+            )
+            .join('\n'),
         )
-        .join('\n'),
     )
-  return html
+  }
 }
 
 /**


### PR DESCRIPTION
Resolves #155 

### Why these changes?
- `toComponentByShortcode` was introduced as a renderer configuration option to open the door for _any_ component framework to support shortcodes! This utility is meant to wrap the string of HTML generated by a shortcode with a component, using the framework's implementation to set inner HTML.
- `handleSSRComments` is now _recursive._ This is meant to support shortcodes that hydrate other components. First, render the page itself, then render any shortcodes generated by that page.
- set up a makeshift example in Vue to prove out the concept further. Left a TODO to refine prop passing, but it should work well as a tech demo in the meantime