### PR TITLE
Fix: 0.6.0 production builds

### DIFF
--- a/packages/slinkity-renderer-svelte/index.js
+++ b/packages/slinkity-renderer-svelte/index.js
@@ -12,7 +12,9 @@ module.exports = {
   extensions: ['svelte'],
   client,
   server,
-  injectImportedStyles: true,
+  // injected styles will throw for non-hydrated components in production builds
+  // TODO: enable when we find a fix
+  injectImportedStyles: false,
   viteConfig() {
     return {
       optimizeDeps: {

--- a/packages/slinkity-renderer-svelte/package-lock.json
+++ b/packages/slinkity-renderer-svelte/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@slinkity/renderer-svelte",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/slinkity-renderer-svelte/package.json
+++ b/packages/slinkity-renderer-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slinkity/renderer-svelte",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Svelte component renderer for the legendary 11ty tool, Slinkity",
   "main": "index.js",
   "files": [

--- a/packages/slinkity-renderer-svelte/server.js
+++ b/packages/slinkity-renderer-svelte/server.js
@@ -3,10 +3,10 @@ import SvelteWrapper from './Wrapper.svelte.ssr.js'
 export default async function server({ toCommonJSModule, componentPath, props, children }) {
   const { default: Component } = await toCommonJSModule(componentPath)
 
-  const { html } = SvelteWrapper.render({
+  const { html, css } = SvelteWrapper.render({
     __slinkity_component: Component,
     __slinkity_children: children,
     ...props,
   })
-  return { html }
+  return { html, css: css.code }
 }

--- a/packages/slinkity/cli/eleventy.js
+++ b/packages/slinkity/cli/eleventy.js
@@ -86,7 +86,7 @@ async function startEleventy({ dir, userSlinkityConfig, options }) {
   })
 
   /** @type {import('../eleventyConfig/types').Environment} */
-  const environment = options.watch ? 'dev' : 'prod'
+  const environment = options.watch ? 'development' : 'production'
   const config = toEleventyConfig({
     dir,
     environment,

--- a/packages/slinkity/cli/toViteSSR.js
+++ b/packages/slinkity/cli/toViteSSR.js
@@ -1,4 +1,5 @@
 const { createServer, build, defineConfig, mergeConfig } = require('vite')
+const path = require('path')
 const requireFromString = require('require-from-string')
 const logger = require('../utils/logger')
 const { getSharedConfig } = require('./vite')
@@ -47,6 +48,8 @@ module.exports.collectCSS = collectCSS
  * @returns {FormattedModule}
  */
 async function viteBuild({ ssrViteConfig, filePath, environment }) {
+  const isNpmPackage = /^[^./]|^\.[^./]|^\.\.[^/]/
+  const input = isNpmPackage.test(filePath) ? path.resolve('node_modules', filePath) : filePath
   const { output } = await build({
     ...ssrViteConfig,
     mode: environment,
@@ -54,7 +57,7 @@ async function viteBuild({ ssrViteConfig, filePath, environment }) {
       ssr: true,
       write: false,
       rollupOptions: {
-        input: filePath,
+        input,
       },
     },
   })

--- a/packages/slinkity/cli/toViteSSR.js
+++ b/packages/slinkity/cli/toViteSSR.js
@@ -45,7 +45,7 @@ module.exports.collectCSS = collectCSS
  * @property {string} filePath
  * @property {import('../eleventyConfig/types').Environment} environment
  * @param {ViteBuildParams}
- * @returns {FormattedModule}
+ * @returns {DefaultModule}
  */
 async function viteBuild({ ssrViteConfig, filePath, environment }) {
   const isNpmPackage = /^[^./]|^\.[^./]|^\.\.[^/]/
@@ -61,11 +61,9 @@ async function viteBuild({ ssrViteConfig, filePath, environment }) {
       },
     },
   })
-  /** @type {FormattedModule} */
+  /** @type {DefaultModule} */
   const defaultMod = {
     default: () => null,
-    getProps: () => ({}),
-    frontMatter: {},
     __importedStyles: new Set(),
   }
   if (!output?.length) {
@@ -93,10 +91,8 @@ async function viteBuild({ ssrViteConfig, filePath, environment }) {
  * @property {import('./types').UserSlinkityConfig} userSlinkityConfig
  * @param {ViteSSRParams}
  *
- * @typedef FormattedModule
+ * @typedef DefaultModule
  * @property {() => any} default
- * @property {(eleventyData: any) => any} getProps
- * @property {Record<string, any>} frontMatter
  * @property {Set<string>} __importedStyles
  *
  * @typedef {import('./types').ViteSSR} ViteSSR
@@ -107,10 +103,10 @@ async function toViteSSR({ environment, dir, userSlinkityConfig }) {
   const sharedConfig = await getSharedConfig({ dir, userSlinkityConfig })
   const ssrViteConfig = defineConfig(mergeConfig({ root: dir.output }, sharedConfig))
 
-  /** @type {Record<string, FormattedModule>} */
+  /** @type {Record<string, DefaultModule>} */
   const probablyInefficientCache = {}
 
-  if (environment === 'dev') {
+  if (environment === 'development') {
     /** @type {import('vite').ViteDevServer} */
     let server = null
     return {
@@ -118,7 +114,7 @@ async function toViteSSR({ environment, dir, userSlinkityConfig }) {
         if (options.useCache && probablyInefficientCache[filePath]) {
           return probablyInefficientCache[filePath]
         }
-        /** @type {FormattedModule} */
+        /** @type {DefaultModule} */
         let viteOutput
         if (server) {
           const ssrModule = await server.ssrLoadModule(filePath)
@@ -128,8 +124,6 @@ async function toViteSSR({ environment, dir, userSlinkityConfig }) {
           collectCSS(moduleGraph, __importedStyles)
           viteOutput = {
             default: () => null,
-            getProps: () => ({}),
-            frontMatter: {},
             __importedStyles,
             ...ssrModule,
           }

--- a/packages/slinkity/cli/vite.js
+++ b/packages/slinkity/cli/vite.js
@@ -87,6 +87,7 @@ async function build({ eleventyDir, userSlinkityConfig, input, output }) {
       vite.mergeConfig(
         {
           root: input,
+          mode: 'production',
           build: {
             outDir: output,
             emptyOutDir: true,

--- a/packages/slinkity/eleventyConfig/applyViteHtmlTransform.js
+++ b/packages/slinkity/eleventyConfig/applyViteHtmlTransform.js
@@ -161,7 +161,7 @@ async function applyViteHtmlTransform({
   })
   const server = viteSSR.getServer()
   const routePath = '/' + toSlashesTrimmed(normalizePath(relative(dir.output, outputPath)))
-  return environment === 'dev' && server ? server.transformIndexHtml(routePath, html) : html
+  return environment === 'development' && server ? server.transformIndexHtml(routePath, html) : html
 }
 
 module.exports = { applyViteHtmlTransform, handleSSRComments }

--- a/packages/slinkity/eleventyConfig/applyViteHtmlTransform.test.js
+++ b/packages/slinkity/eleventyConfig/applyViteHtmlTransform.test.js
@@ -23,7 +23,7 @@ function toConvincingUrl(fileName) {
 }
 
 describe('applyViteHtmlTransform', () => {
-  const environments = ['prod', 'dev']
+  const environments = ['production', 'development']
   it.each(environments)(
     'should not try and parse files that are not html for %s',
     async (environment) => {

--- a/packages/slinkity/eleventyConfig/index.js
+++ b/packages/slinkity/eleventyConfig/index.js
@@ -64,7 +64,7 @@ module.exports = function toEleventyConfig({ userSlinkityConfig, ...options }) {
       }
     }
 
-    if (environment === 'dev') {
+    if (environment === 'development') {
       const urlToOutputHtmlMap = {}
 
       eleventyConfig.on('beforeBuild', () => {
@@ -121,7 +121,7 @@ module.exports = function toEleventyConfig({ userSlinkityConfig, ...options }) {
       )
     }
 
-    if (environment === 'prod') {
+    if (environment === 'production') {
       eleventyConfig.addTransform('apply-vite', async function (content, outputPath) {
         return await applyViteHtmlTransform({
           content,

--- a/packages/slinkity/eleventyConfig/types.d.ts
+++ b/packages/slinkity/eleventyConfig/types.d.ts
@@ -2,7 +2,7 @@ import type { ViteSSR } from "../cli/toViteSSR"
 import type { UserSlinkityConfig } from '..'
 import type { Options } from 'browser-sync'
 
-type Environment = 'dev' | 'prod'
+type Environment = 'development' | 'production'
 
 /** Paths to all significant directories, as specified in 11ty's "dir" documentation */
 export type Dir = {

--- a/packages/slinkity/package-lock.json
+++ b/packages/slinkity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "slinkity",
-  "version": "0.6.1-canary.0",
+  "version": "0.6.1-canary.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/slinkity/package.json
+++ b/packages/slinkity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slinkity",
   "description": "To 11ty and beyond! The all-in-one tool for templates where you want them, component frameworks where you need them",
-  "version": "0.6.1-canary.0",
+  "version": "0.6.1-canary.2",
   "license": "MIT",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## What's fixed?
- Node modules as rollup entrypoints are now resolved to `node_modules`. This is accomplished with a regex under the `viteBuild` function
- Svelte component styles now injected via `<style>` tags. This is due to a limitation with production builds: if you don't hydrate a component, you can't load that component's styles via the `style` tag (as you might with Vue). Ideally, we'd inject styles into the `head` like so to allow shared stylesheets between pages: `<script type="module" src="/Users/me/slinkity-site/src/_includes/Slinky.svelte?svelte&type=style&lang.css"></script>`
- The `env` was changed from `dev | prod` to `development | production`. This was a super in-the-weeds issue with Vue style compilation, where failing to use the string "production" would break style scoping in production!