### PR TITLE
Fix: Windows path resolution

### DIFF
--- a/packages/slinkity-renderer-react/index.js
+++ b/packages/slinkity-renderer-react/index.js
@@ -1,9 +1,8 @@
-const { join } = require('path')
-const packageMeta = require('./package.json')
+const pkg = require('./package.json')
 
-const client = join(packageMeta.name, 'client')
-const server = join(packageMeta.name, 'server')
-const toComponentByShortcode = join(packageMeta.name, 'StaticHtml')
+const client = `${pkg.name}/client`
+const server = `${pkg.name}/server`
+const toComponentByShortcode = `${pkg.name}/StaticHtml`
 
 /** @type {import('../slinkity').Renderer} */
 module.exports = {

--- a/packages/slinkity-renderer-react/package-lock.json
+++ b/packages/slinkity-renderer-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@slinkity/renderer-react",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/slinkity-renderer-react/package.json
+++ b/packages/slinkity-renderer-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slinkity/renderer-react",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "React component renderer for the legendary 11ty tool, Slinkity",
   "main": "index.js",
   "files": [

--- a/packages/slinkity-renderer-svelte/index.js
+++ b/packages/slinkity-renderer-svelte/index.js
@@ -1,10 +1,9 @@
-const { join } = require('path')
-const packageMeta = require('./package.json')
+const pkg = require('./package.json')
 const { svelte } = require('@sveltejs/vite-plugin-svelte')
 const preprocess = require('svelte-preprocess')
 
-const client = join(packageMeta.name, 'client')
-const server = join(packageMeta.name, 'server')
+const client = `${pkg.name}/client`
+const server = `${pkg.name}/server`
 
 /** @type {import('../slinkity').Renderer} */
 module.exports = {

--- a/packages/slinkity-renderer-svelte/package-lock.json
+++ b/packages/slinkity-renderer-svelte/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@slinkity/renderer-svelte",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/slinkity-renderer-svelte/package.json
+++ b/packages/slinkity-renderer-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slinkity/renderer-svelte",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Svelte component renderer for the legendary 11ty tool, Slinkity",
   "main": "index.js",
   "files": [

--- a/packages/slinkity-renderer-vue/index.js
+++ b/packages/slinkity-renderer-vue/index.js
@@ -1,10 +1,9 @@
-const { join } = require('path')
-const packageMeta = require('./package.json')
+const pkg = require('./package.json')
 const vue = require('@vitejs/plugin-vue')
 
-const client = join(packageMeta.name, 'client')
-const server = join(packageMeta.name, 'server')
-const toComponentByShortcode = join(packageMeta.name, 'StaticHtml')
+const client = `${pkg.name}/client`
+const server = `${pkg.name}/server`
+const toComponentByShortcode = `${pkg.name}/StaticHtml`
 
 /** @type {import('../slinkity').Renderer} */
 module.exports = {

--- a/packages/slinkity-renderer-vue/package-lock.json
+++ b/packages/slinkity-renderer-vue/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@slinkity/renderer-vue",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/slinkity-renderer-vue/package.json
+++ b/packages/slinkity-renderer-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slinkity/renderer-vue",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Vue component renderer for the legendary 11ty tool, Slinkity",
   "main": "index.js",
   "files": [

--- a/packages/slinkity/build.js
+++ b/packages/slinkity/build.js
@@ -11,7 +11,7 @@ const makeAllPackagesExternalPlugin = {
   },
 }
 
-const entryPoints = [path.resolve(__dirname, 'cli/index.js')]
+const entryPoints = ['cli/index.js']
 const isWatchEnabled = process.argv.includes('--watch')
 let watch = false
 if (isWatchEnabled) {


### PR DESCRIPTION
Remove usages of `path.join` across 1) renderer package names and 2) our esbuild script