### PR TITLE
Feat: support children with new component shortcode

### DIFF
--- a/packages/create-slinkity/cli.js
+++ b/packages/create-slinkity/cli.js
@@ -28,7 +28,7 @@ const componentFlavorMeta = {
       href: '/react-page',
       text: 'React',
     },
-    shortcode: '{% react "Slinky", hydrate="eager" %}',
+    shortcode: '{% component "Slinky.jsx", hydrate="eager" %}',
     exclusiveTemplates: ['src/react-page.jsx', 'src/_includes/Slinky.jsx', 'styles/slinky.scss'],
   },
   vue: {
@@ -48,7 +48,7 @@ const componentFlavorMeta = {
       href: '/vue-page',
       text: 'Vue',
     },
-    shortcode: '{% vue "Slinky.vue", hydrate="eager" %}',
+    shortcode: '{% component "Slinky.vue", hydrate="eager" %}',
     exclusiveTemplates: ['src/vue-page.vue', 'src/_includes/Slinky.vue'],
   },
   svelte: {
@@ -68,7 +68,7 @@ const componentFlavorMeta = {
       href: '/svelte-page',
       text: 'Svelte',
     },
-    shortcode: '{% svelte "Slinky.svelte", hydrate="eager" %}',
+    shortcode: '{% component "Slinky.svelte", hydrate="eager" %}',
     exclusiveTemplates: ['src/svelte-page.svelte', 'src/_includes/Slinky.svelte'],
   },
 }

--- a/packages/create-slinkity/package.json
+++ b/packages/create-slinkity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-slinkity",
-  "version": "1.1.1-canary.1",
+  "version": "1.1.1-canary.2",
   "description": "The splendid starter to scaffold your Slinkity site.",
   "main": "cli.js",
   "repository": {

--- a/packages/slinkity-renderer-react/client.js
+++ b/packages/slinkity-renderer-react/client.js
@@ -1,6 +1,10 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import StaticHtml from './StaticHtml'
 
-export default function renderComponent({ Component, target, props = {} }) {
-  ReactDOM.render(React.createElement(Component, props, null), target)
+export default function renderComponent({ Component, target, props, children }) {
+  ReactDOM.render(
+    React.createElement(Component, props, React.createElement(StaticHtml, { value: children })),
+    target,
+  )
 }

--- a/packages/slinkity-renderer-react/index.js
+++ b/packages/slinkity-renderer-react/index.js
@@ -1,9 +1,8 @@
-const { join } = require('path')
-const packageMeta = require('./package.json')
+const pkg = require('./package.json')
 
-const client = join(packageMeta.name, 'client')
-const server = join(packageMeta.name, 'server')
-const toComponentByShortcode = join(packageMeta.name, 'StaticHtml')
+const client = `${pkg.name}/client`
+const server = `${pkg.name}/server`
+const toComponentByShortcode = `${pkg.name}/StaticHtml`
 
 /** @type {import('../slinkity').Renderer} */
 module.exports = {

--- a/packages/slinkity-renderer-react/package.json
+++ b/packages/slinkity-renderer-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slinkity/renderer-react",
-  "version": "0.1.3",
+  "version": "0.1.5",
   "description": "React component renderer for the legendary 11ty tool, Slinkity",
   "main": "index.js",
   "files": [

--- a/packages/slinkity-renderer-svelte/index.js
+++ b/packages/slinkity-renderer-svelte/index.js
@@ -1,10 +1,9 @@
-const { join } = require('path')
-const packageMeta = require('./package.json')
+const pkg = require('./package.json')
 const { svelte } = require('@sveltejs/vite-plugin-svelte')
 const preprocess = require('svelte-preprocess')
 
-const client = join(packageMeta.name, 'client')
-const server = join(packageMeta.name, 'server')
+const client = `${pkg.name}/client`
+const server = `${pkg.name}/server`
 
 /** @type {import('../slinkity').Renderer} */
 module.exports = {

--- a/packages/slinkity-renderer-svelte/package.json
+++ b/packages/slinkity-renderer-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slinkity/renderer-svelte",
-  "version": "0.1.4",
+  "version": "0.1.6",
   "description": "Svelte component renderer for the legendary 11ty tool, Slinkity",
   "main": "index.js",
   "files": [

--- a/packages/slinkity-renderer-vue/index.js
+++ b/packages/slinkity-renderer-vue/index.js
@@ -1,10 +1,9 @@
-const { join } = require('path')
-const packageMeta = require('./package.json')
+const pkg = require('./package.json')
 const vue = require('@vitejs/plugin-vue')
 
-const client = join(packageMeta.name, 'client')
-const server = join(packageMeta.name, 'server')
-const toComponentByShortcode = join(packageMeta.name, 'StaticHtml')
+const client = `${pkg.name}/client`
+const server = `${pkg.name}/server`
+const toComponentByShortcode = `${pkg.name}/StaticHtml`
 
 /** @type {import('../slinkity').Renderer} */
 module.exports = {

--- a/packages/slinkity-renderer-vue/package.json
+++ b/packages/slinkity-renderer-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slinkity/renderer-vue",
-  "version": "0.1.3",
+  "version": "0.1.5",
   "description": "Vue component renderer for the legendary 11ty tool, Slinkity",
   "main": "index.js",
   "files": [

--- a/packages/slinkity/build.js
+++ b/packages/slinkity/build.js
@@ -11,7 +11,7 @@ const makeAllPackagesExternalPlugin = {
   },
 }
 
-const entryPoints = [path.resolve(__dirname, 'cli/index.js')]
+const entryPoints = ['cli/index.js']
 const isWatchEnabled = process.argv.includes('--watch')
 let watch = false
 if (isWatchEnabled) {

--- a/packages/slinkity/client/eagerLoader.js
+++ b/packages/slinkity/client/eagerLoader.js
@@ -1,6 +1,6 @@
 import { toMountPointById } from './toMountPointById'
 
-export default function eagerLoader({ id, Component, props, renderer }) {
+export default function eagerLoader({ id, Component, props, children, renderer }) {
   const target = toMountPointById(id)
-  renderer({ Component, target, props })
+  renderer({ Component, target, props, children })
 }

--- a/packages/slinkity/client/lazyLoader.js
+++ b/packages/slinkity/client/lazyLoader.js
@@ -5,7 +5,7 @@ const options = {
   threshold: 0,
 }
 
-export default function lazyLoader({ id, props, toComponent, toRenderer }) {
+export default function lazyLoader({ id, props, children, toComponent, toRenderer }) {
   const observer = new IntersectionObserver(async function (entries) {
     for (const entry of entries) {
       if (entry.isIntersecting) {
@@ -13,7 +13,7 @@ export default function lazyLoader({ id, props, toComponent, toRenderer }) {
         if (!target.getAttribute('data-s-is-hydrated')) {
           const { default: renderer } = await toRenderer()
           const { default: Component } = await toComponent()
-          renderer({ Component, target, props })
+          renderer({ Component, target, props, children })
           target.setAttribute('data-s-is-hydrated', true)
         }
       }

--- a/packages/slinkity/eleventyConfig/__snapshots__/applyViteHtmlTransform.test.js.snap
+++ b/packages/slinkity/eleventyConfig/__snapshots__/applyViteHtmlTransform.test.js.snap
@@ -1,11 +1,129 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`applyViteHtmlTransform handleSSRComments should inject children as string 1`] = `
+"
+<html>
+<head>
+  <title>It's hydration time</title>
+</head>
+<body>
+<slinkity-react-mount-point data-s-id=\\"0\\"><react>Content</react>
+  <p>rendered by react</p></slinkity-react-mount-point>
+<script type=\\"module\\">
+    import Component0 from \\"nice.jsx\\";
+    import renderer0 from \\"@slinkity/example/client\\";
+    import { eagerLoader as eagerLoader0 } from \\"slinkity/client\\";
+  
+    eagerLoader0({ 
+      id: \\"0\\",
+      Component: Component0,
+      renderer: renderer0,
+      props: {},
+      children: \`
+<h2>Boy do I love react!</h2>\`,
+    });
+  </script>
+<slinkity-react-mount-point data-s-id=\\"1\\"><svelte>Content</svelte>
+  <p>rendered by svelte</p></slinkity-react-mount-point>
+<script type=\\"module\\">
+    import Component1 from \\"cool.svelte\\";
+    import renderer1 from \\"@slinkity/svelte/client\\";
+    import { eagerLoader as eagerLoader1 } from \\"slinkity/client\\";
+  
+    eagerLoader1({ 
+      id: \\"1\\",
+      Component: Component1,
+      renderer: renderer1,
+      props: {},
+      children: \`
+<h2>Boy do I love svelte!</h2>\`,
+    });
+  </script>
+<slinkity-react-mount-point data-s-id=\\"2\\"><vue>Content</vue>
+  <p>rendered by vue</p></slinkity-react-mount-point>
+<script type=\\"module\\">
+    import Component2 from \\"neat.vue\\";
+    import renderer2 from \\"@slinkity/vue/client\\";
+    import { eagerLoader as eagerLoader2 } from \\"slinkity/client\\";
+  
+    eagerLoader2({ 
+      id: \\"2\\",
+      Component: Component2,
+      renderer: renderer2,
+      props: {},
+      children: \`
+<h2>Boy do I love vue!</h2>\`,
+    });
+  </script>
+</body>
+</html>"
+`;
+
+exports[`applyViteHtmlTransform handleSSRComments should inject props as object 1`] = `
+"
+<html>
+<head>
+  <title>It's hydration time</title>
+</head>
+<body>
+<slinkity-react-mount-point data-s-id=\\"0\\"><react>Content</react>
+  <p>rendered by react</p></slinkity-react-mount-point>
+<script type=\\"module\\">
+    import Component0 from \\"nice.jsx\\";
+    import renderer0 from \\"@slinkity/example/client\\";
+    import { eagerLoader as eagerLoader0 } from \\"slinkity/client\\";
+  
+    eagerLoader0({ 
+      id: \\"0\\",
+      Component: Component0,
+      renderer: renderer0,
+      props: {rendererName:'react',outputPath:'/handle/ssr/comments.html',componentPath:'nice.jsx',nullValue:null,number:42},
+      children: \`
+\`,
+    });
+  </script>
+<slinkity-react-mount-point data-s-id=\\"1\\"><svelte>Content</svelte>
+  <p>rendered by svelte</p></slinkity-react-mount-point>
+<script type=\\"module\\">
+    import Component1 from \\"cool.svelte\\";
+    import renderer1 from \\"@slinkity/svelte/client\\";
+    import { eagerLoader as eagerLoader1 } from \\"slinkity/client\\";
+  
+    eagerLoader1({ 
+      id: \\"1\\",
+      Component: Component1,
+      renderer: renderer1,
+      props: {rendererName:'svelte',outputPath:'/handle/ssr/comments.html',componentPath:'cool.svelte',nullValue:null,number:42},
+      children: \`
+\`,
+    });
+  </script>
+<slinkity-react-mount-point data-s-id=\\"2\\"><vue>Content</vue>
+  <p>rendered by vue</p></slinkity-react-mount-point>
+<script type=\\"module\\">
+    import Component2 from \\"neat.vue\\";
+    import renderer2 from \\"@slinkity/vue/client\\";
+    import { eagerLoader as eagerLoader2 } from \\"slinkity/client\\";
+  
+    eagerLoader2({ 
+      id: \\"2\\",
+      Component: Component2,
+      renderer: renderer2,
+      props: {rendererName:'vue',outputPath:'/handle/ssr/comments.html',componentPath:'neat.vue',nullValue:null,number:42},
+      children: \`
+\`,
+    });
+  </script>
+</body>
+</html>"
+`;
+
 exports[`applyViteHtmlTransform handleSSRComments should inject styles into head 1`] = `
 "
 <html>
 <head>
   <title>It's hydration time</title>
-  <link rel=\\"stylesheet\\" href=\\"/@fs/Users/person/project/styles.scss\\">
+<link rel=\\"stylesheet\\" href=\\"/@fs/Users/person/project/styles.scss\\">
 <link rel=\\"stylesheet\\" href=\\"/@fs/Users/person/project/more-styles.scss\\">
 <link rel=\\"stylesheet\\" href=\\"/@fs/Users/person/project/nested/global.module.scss\\">
 <link rel=\\"stylesheet\\" href=\\"/@fs/Users/person/project/excellent.css\\">
@@ -23,7 +141,7 @@ exports[`applyViteHtmlTransform handleSSRComments should replace SSR comments wi
   <title>It's hydration time</title>
 </head>
 <body>
-  <slinkity-react-mount-point data-s-id=\\"0\\"><react>Content</react>
+<slinkity-react-mount-point data-s-id=\\"0\\"><react>Content</react>
   <p>rendered by react</p></slinkity-react-mount-point>
 <script type=\\"module\\">
     import Component0 from \\"nice.jsx\\";
@@ -35,6 +153,8 @@ exports[`applyViteHtmlTransform handleSSRComments should replace SSR comments wi
       Component: Component0,
       renderer: renderer0,
       props: {},
+      children: \`
+\`,
     });
   </script>
 <slinkity-react-mount-point data-s-id=\\"1\\"><svelte>Content</svelte>
@@ -49,6 +169,8 @@ exports[`applyViteHtmlTransform handleSSRComments should replace SSR comments wi
       Component: Component1,
       renderer: renderer1,
       props: {},
+      children: \`
+\`,
     });
   </script>
 <slinkity-react-mount-point data-s-id=\\"2\\"><vue>Content</vue>
@@ -63,6 +185,8 @@ exports[`applyViteHtmlTransform handleSSRComments should replace SSR comments wi
       Component: Component2,
       renderer: renderer2,
       props: {},
+      children: \`
+\`,
     });
   </script>
 </body>

--- a/packages/slinkity/eleventyConfig/addComponentShortcodes.js
+++ b/packages/slinkity/eleventyConfig/addComponentShortcodes.js
@@ -34,20 +34,23 @@ module.exports = function addComponentShortcode({
     return toSSRComment(id)
   })
 
-  eleventyConfig.addPairedShortcode('componentWrap', function (content, componentPath, ...vargs) {
-    const id = componentAttrStore.push(
-      toComponentAttrStoreEntry({
-        componentPath,
-        vargs,
-        children: content,
-        resolvedImportAliases,
-        extensionToRendererMap,
-        page: this.page,
-      }),
-    )
+  eleventyConfig.addPairedShortcode(
+    'slottedComponent',
+    function (content, componentPath, ...vargs) {
+      const id = componentAttrStore.push(
+        toComponentAttrStoreEntry({
+          componentPath,
+          vargs,
+          children: content,
+          resolvedImportAliases,
+          extensionToRendererMap,
+          page: this.page,
+        }),
+      )
 
-    return toSSRComment(id)
-  })
+      return toSSRComment(id)
+    },
+  )
 }
 
 const argsArrayToPropsObj = function ({ vargs = [], errorMsg = '' }) {

--- a/packages/slinkity/eleventyConfig/addComponentShortcodes.test.js
+++ b/packages/slinkity/eleventyConfig/addComponentShortcodes.test.js
@@ -1,8 +1,5 @@
 const { argsArrayToPropsObj } = require('./addComponentShortcodes')
 const { random, datatype } = require('faker')
-const logger = require('../utils/logger')
-
-jest.mock('../utils/logger')
 
 describe('argsArrayToPropsObj', () => {
   it('should generate an empty object for empty arrays', () => {
@@ -29,13 +26,11 @@ describe('argsArrayToPropsObj', () => {
 
     expect(argsArrayToPropsObj({ vargs })).toEqual(expected)
   })
-  it('should log a warning for invalid props array', () => {
+  it('should throw for invalid props array', () => {
     const vargs = ['all work', 'and no play', 'makes Jack']
-    const spy = jest.spyOn(logger, 'log')
     const errorMsg = 'Uh oh! We made a boo boo'
 
-    expect(argsArrayToPropsObj({ vargs, errorMsg })).toEqual({})
-    expect(spy).toHaveBeenCalledWith({ message: errorMsg, type: 'warning' })
+    expect(() => argsArrayToPropsObj({ vargs, errorMsg })).toThrow(new Error(errorMsg))
   })
   it('should return empty object when no params are passed', () => {
     expect(argsArrayToPropsObj({})).toEqual({})

--- a/packages/slinkity/eleventyConfig/applyViteHtmlTransform.js
+++ b/packages/slinkity/eleventyConfig/applyViteHtmlTransform.js
@@ -41,7 +41,7 @@ async function handleSSRComments({
   const pageComponentAttrs = componentAttrStore.getAllByPage(outputPath)
   const serverRenderedComponents = []
   for (const componentAttrs of pageComponentAttrs) {
-    const { path: componentPath, props, hydrate, rendererName } = componentAttrs
+    const { path: componentPath, props, hydrate, rendererName, children } = componentAttrs
     const renderer = rendererMap[rendererName]
     const { default: serverRenderer } = await viteSSR.toCommonJSModule(renderer.server)
     if (renderer.injectImportedStyles) {
@@ -76,8 +76,7 @@ async function handleSSRComments({
       toCommonJSModule: viteSSR.toCommonJSModule,
       componentPath,
       props: propsWithShortcodes,
-      // TODO: add children to componentAttrStore
-      children: '',
+      children,
       hydrate,
     })
     if (serverRendered.css) {
@@ -89,9 +88,16 @@ async function handleSSRComments({
   const html = content
     // server render each component
     .replace(ssrRegex, (_, id) => {
-      const { path: componentPath, props, hydrate, rendererName } = pageComponentAttrs[id]
+      const { path: componentPath, props, hydrate, rendererName, children } = pageComponentAttrs[id]
       const clientRenderer = rendererMap[rendererName].client
-      const loaderScript = toLoaderScript({ componentPath, props, hydrate, id, clientRenderer })
+      const loaderScript = toLoaderScript({
+        componentPath,
+        props,
+        hydrate,
+        id,
+        clientRenderer,
+        children,
+      })
       const attrs = toHtmlAttrString({ [SLINKITY_ATTRS.id]: id })
       return `<${SLINKITY_REACT_MOUNT_POINT} ${attrs}>${serverRenderedComponents[id]}</${SLINKITY_REACT_MOUNT_POINT}>\n${loaderScript}`
     })

--- a/packages/slinkity/eleventyConfig/componentAttrStore.js
+++ b/packages/slinkity/eleventyConfig/componentAttrStore.js
@@ -9,6 +9,7 @@
  * @property {string} path - the component's file path
  * @property {string} rendererName - name of renderer to use for component
  * @property {Record<string, any>} props - all props passed to the component
+ * @property {string} children - stringified HTML children
  * @property {'eager' | 'lazy' | 'static'} hydrate - mode to use when hydrating the component
  * @property {string} pageOutputPath - the page where this component lives, based on 11ty's inputPath property (ex. src/index.html)
  * @property {ID} id - a unique identifier for later retrieval from the store

--- a/packages/slinkity/eleventyConfig/index.js
+++ b/packages/slinkity/eleventyConfig/index.js
@@ -46,13 +46,13 @@ module.exports = function toEleventyConfig({ userSlinkityConfig, ...options }) {
     })
 
     const resolvedImportAliases = getResolvedAliases(dir)
+    addComponentShortcodes({
+      renderers: userSlinkityConfig.renderers,
+      eleventyConfig,
+      resolvedImportAliases,
+      componentAttrStore,
+    })
     for (const renderer of userSlinkityConfig.renderers) {
-      addComponentShortcodes({
-        renderer,
-        eleventyConfig,
-        resolvedImportAliases,
-        componentAttrStore,
-      })
       if (renderer.page) {
         addComponentPages({
           renderer,

--- a/packages/slinkity/eleventyConfig/toLoaderScript.js
+++ b/packages/slinkity/eleventyConfig/toLoaderScript.js
@@ -9,10 +9,18 @@ const { normalizePath } = require('vite')
  * @property {string} id - the unique id for a given mount point
  * @property {'eager' | 'lazy'} hydrate - which hydration loader to use
  * @property {Record<string, any>} props - data used when hydrating the component
+ * @property {string} children - Stringified HTML children
  * @param {LoaderScriptParams}
  * @returns {string} String of HTML to run loader in the client
  */
-module.exports = function toLoaderScript({ componentPath, hydrate, id, props, clientRenderer }) {
+module.exports = function toLoaderScript({
+  componentPath,
+  hydrate,
+  id,
+  props,
+  clientRenderer,
+  children,
+}) {
   // TODO: abstract "props" to some other file, instead of stringifying in-place
   // We could be generating identical, large prop blobs
   const componentImportPath = JSON.stringify(normalizePath(componentPath))
@@ -28,6 +36,8 @@ module.exports = function toLoaderScript({ componentPath, hydrate, id, props, cl
       Component: Component${id},
       renderer: renderer${id},
       props: ${stringify(props)},
+      children: \`
+${children}\`,
     });
   </script>`
   } else if (hydrate === 'lazy') {
@@ -39,6 +49,8 @@ module.exports = function toLoaderScript({ componentPath, hydrate, id, props, cl
       toComponent: async () => await import(${componentImportPath}),
       toRenderer: async () => await import(${rendererImportPath}),
       props: ${stringify(props)},
+      children: \`
+${children}\`,
     });
   </script>`
   } else {

--- a/packages/slinkity/eleventyConfig/toLoaderScript.js
+++ b/packages/slinkity/eleventyConfig/toLoaderScript.js
@@ -37,7 +37,7 @@ module.exports = function toLoaderScript({
       renderer: renderer${id},
       props: ${stringify(props)},
       children: \`
-${children}\`,
+${children ?? ''}\`,
     });
   </script>`
   } else if (hydrate === 'lazy') {
@@ -50,7 +50,7 @@ ${children}\`,
       toRenderer: async () => await import(${rendererImportPath}),
       props: ${stringify(props)},
       children: \`
-${children}\`,
+${children ?? ''}\`,
     });
   </script>`
   } else {

--- a/packages/slinkity/package.json
+++ b/packages/slinkity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slinkity",
   "description": "To 11ty and beyond! The all-in-one tool for templates where you want them, component frameworks where you need them",
-  "version": "0.6.1-canary.2",
+  "version": "0.6.1-canary.3",
   "license": "MIT",
   "main": "index.js",
   "types": "index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,7 +131,7 @@ importers:
       react: ^17.0.2
       react-dom: ^17.0.2
       sass: ^1.42.1
-      slinkity: '*'
+      slinkity: workspace:*
     devDependencies:
       '@11ty/eleventy': 1.0.0
       '@11ty/eleventy-cache-assets': 2.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,7 +123,7 @@ importers:
 
   www:
     specifiers:
-      '@11ty/eleventy': ^1.0.0-beta.9
+      '@11ty/eleventy': ^1.0.0
       '@11ty/eleventy-cache-assets': ^2.3.0
       '@11ty/eleventy-plugin-syntaxhighlight': ^3.1.2
       js-yaml: ^3.14.1
@@ -131,7 +131,7 @@ importers:
       react: ^17.0.2
       react-dom: ^17.0.2
       sass: ^1.42.1
-      slinkity: ^0.4.2
+      slinkity: '*'
     devDependencies:
       '@11ty/eleventy': 1.0.0
       '@11ty/eleventy-cache-assets': 2.3.0
@@ -141,7 +141,7 @@ importers:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       sass: 1.49.0
-      slinkity: 0.4.4_c1fe87f73d70d8e087787d786e9215f3
+      slinkity: link:../packages/slinkity
 
 packages:
 
@@ -1646,6 +1646,7 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@parcel/css-darwin-x64/1.1.0:
@@ -1654,6 +1655,7 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@parcel/css-linux-arm-gnueabihf/1.1.0:
@@ -1662,6 +1664,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@parcel/css-linux-arm64-gnu/1.1.0:
@@ -1670,6 +1673,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@parcel/css-linux-arm64-musl/1.1.0:
@@ -1678,6 +1682,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@parcel/css-linux-x64-gnu/1.1.0:
@@ -1686,6 +1691,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@parcel/css-linux-x64-musl/1.1.0:
@@ -1694,6 +1700,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@parcel/css-win32-x64-msvc/1.1.0:
@@ -1702,6 +1709,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@parcel/css/1.1.0:
@@ -1718,6 +1726,7 @@ packages:
       '@parcel/css-linux-x64-gnu': 1.1.0
       '@parcel/css-linux-x64-musl': 1.1.0
       '@parcel/css-win32-x64-msvc': 1.1.0
+    dev: false
 
   /@rollup/pluginutils/4.1.2:
     resolution: {integrity: sha512-ROn4qvkxP9SyPeHaf7uQC/GPFY6L/OWy9+bd9AwcjOAWQwxRscoEyAUD8qCY5o5iL4jqQwoLk2kaTKJPb/HwzQ==}
@@ -2227,6 +2236,7 @@ packages:
   /at-least-node/1.0.0:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
+    dev: false
 
   /axios/0.21.4_debug@4.3.2:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
@@ -3062,6 +3072,7 @@ packages:
     resolution: {integrity: sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=}
     engines: {node: '>=0.10'}
     hasBin: true
+    dev: false
 
   /detect-newline/3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
@@ -3325,6 +3336,7 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-css-modules-plugin/2.1.1:
@@ -3336,12 +3348,14 @@ packages:
       postcss: 8.4.5
       postcss-modules: 4.3.0_postcss@8.4.5
       tmp: 0.2.1
+    dev: false
 
   /esbuild-darwin-64/0.13.15:
     resolution: {integrity: sha512-ihOQRGs2yyp7t5bArCwnvn2Atr6X4axqPpEdCFPVp7iUj4cVSdisgvEKdNR7yH3JDjW6aQDw40iQFoTqejqxvQ==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-darwin-arm64/0.13.15:
@@ -3349,6 +3363,7 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-freebsd-64/0.13.15:
@@ -3356,6 +3371,7 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-freebsd-arm64/0.13.15:
@@ -3363,6 +3379,7 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-linux-32/0.13.15:
@@ -3370,6 +3387,7 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-linux-64/0.13.15:
@@ -3377,6 +3395,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-linux-arm/0.13.15:
@@ -3384,6 +3403,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-linux-arm64/0.13.15:
@@ -3391,6 +3411,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-linux-mips64le/0.13.15:
@@ -3398,6 +3419,7 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-linux-ppc64le/0.13.15:
@@ -3405,6 +3427,7 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-netbsd-64/0.13.15:
@@ -3412,6 +3435,7 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-openbsd-64/0.13.15:
@@ -3419,6 +3443,7 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-sunos-64/0.13.15:
@@ -3426,6 +3451,7 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-windows-32/0.13.15:
@@ -3433,6 +3459,7 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-windows-64/0.13.15:
@@ -3440,6 +3467,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-windows-arm64/0.13.15:
@@ -3447,12 +3475,14 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild/0.12.29:
     resolution: {integrity: sha512-w/XuoBCSwepyiZtIRsKsetiLDUVGPVw1E/R3VTFSecIy8UR7Cq3SOtwKHJMFoVqqVG36aGkzh4e8BvpO1Fdc7g==}
     hasBin: true
     requiresBuild: true
+    dev: false
 
   /esbuild/0.13.15:
     resolution: {integrity: sha512-raCxt02HBKv8RJxE8vkTSCXGIyKHdEdGfUmiYb8wnabnaEmHzyW7DCHb5tEN0xU8ryqg5xw54mcwnYkC4x3AIw==}
@@ -3476,6 +3506,7 @@ packages:
       esbuild-windows-32: 0.13.15
       esbuild-windows-64: 0.13.15
       esbuild-windows-arm64: 0.13.15
+    dev: false
 
   /escalade/3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -3896,6 +3927,7 @@ packages:
       graceful-fs: 4.2.9
       jsonfile: 6.1.0
       universalify: 2.0.0
+    dev: false
 
   /fs-extra/3.0.1:
     resolution: {integrity: sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=}
@@ -3913,6 +3945,7 @@ packages:
       graceful-fs: 4.2.9
       jsonfile: 6.1.0
       universalify: 2.0.0
+    dev: false
 
   /fs.realpath/1.0.0:
     resolution: {integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=}
@@ -3935,6 +3968,7 @@ packages:
     resolution: {integrity: sha512-ySFolZQfw9FoDb3ed9d80Cm9f0+r7qj+HJkWjeD9RBfpxEVTlVhol+gvaQB/78WbwYfbnNh8nWHHBSlg072y6A==}
     dependencies:
       loader-utils: 3.2.0
+    dev: false
 
   /gensync/1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -4137,11 +4171,6 @@ packages:
     resolution: {integrity: sha1-w/oV8Hjd0WvBULQXb95wkWIPLH8=}
     dev: true
 
-  /he/1.2.0:
-    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
-    hasBin: true
-    dev: true
-
   /hosted-git-info/2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
     dev: true
@@ -4151,13 +4180,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       lru-cache: 6.0.0
-    dev: true
-
-  /html-dom-parser/1.0.4:
-    resolution: {integrity: sha512-ThM/vK/18R5/cVB9UsqhNqbJU7LE2BmSA7C/FjYV88wIDW75GSUpvSE/JxE4mJ8bOuU6Kp15/I1giM2JbD+ieA==}
-    dependencies:
-      domhandler: 4.3.0
-      htmlparser2: 7.2.0
     dev: true
 
   /html-encoding-sniffer/2.0.1:
@@ -4173,18 +4195,6 @@ packages:
 
   /html-escaper/3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
-    dev: true
-
-  /html-react-parser/1.4.5_react@17.0.2:
-    resolution: {integrity: sha512-dxo0z1G9b3mS1VGmcVw4cUGwVsEwkJZZ7r29pOSdE69JukJyFTCL1I6TXSEp2p1LAHvuO6ZBiEVp2M5lXqKLAg==}
-    peerDependencies:
-      react: 0.14 || 15 || 16 || 17
-    dependencies:
-      domhandler: 4.3.0
-      html-dom-parser: 1.0.4
-      react: 17.0.2
-      react-property: 2.0.0
-      style-to-js: 1.1.0
     dev: true
 
   /html-tags/3.1.0:
@@ -4297,6 +4307,7 @@ packages:
 
   /icss-replace-symbols/1.1.0:
     resolution: {integrity: sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=}
+    dev: false
 
   /icss-utils/5.1.0_postcss@8.4.5:
     resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
@@ -4305,6 +4316,7 @@ packages:
       postcss: ^8.1.0
     dependencies:
       postcss: 8.4.5
+    dev: false
 
   /ignore/4.0.6:
     resolution: {integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==}
@@ -4375,10 +4387,6 @@ packages:
 
   /ini/1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
-    dev: true
-
-  /inline-style-parser/0.1.1:
-    resolution: {integrity: sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==}
     dev: true
 
   /internal-slot/1.0.3:
@@ -4653,6 +4661,7 @@ packages:
 
   /javascript-stringify/2.1.0:
     resolution: {integrity: sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==}
+    dev: false
 
   /jest-changed-files/27.4.2:
     resolution: {integrity: sha512-/9x8MjekuzUQoPjDHbBiXbNEBauhrPU2ct7m8TfCg69ywt1y/N+yYwGh3gCpnqUS3klYWDU/lSNgv+JhoD2k1A==}
@@ -5239,6 +5248,7 @@ packages:
       universalify: 2.0.0
     optionalDependencies:
       graceful-fs: 4.2.9
+    dev: false
 
   /jstransformer/1.0.0:
     resolution: {integrity: sha1-7Yvwkh4vPx7U1cGkT2hwntJHIsM=}
@@ -5398,6 +5408,7 @@ packages:
   /loader-utils/3.2.0:
     resolution: {integrity: sha512-HVl9ZqccQihZ7JM85dco1MvO9G+ONvxoGa9rkhzFsneGLKSUg1gJf9bWzhRhcvm2qChhWpebQhP44qxjKIUCaQ==}
     engines: {node: '>= 12.13.0'}
+    dev: false
 
   /localtunnel/2.0.2:
     resolution: {integrity: sha512-n418Cn5ynvJd7m/N1d9WVJISLJF/ellZnfsLnx8WBWGzxv/ntNcFkJ1o6se5quUhCplfLGBNL5tYHiq5WF3Nug==}
@@ -5428,6 +5439,7 @@ packages:
 
   /lodash.camelcase/4.3.0:
     resolution: {integrity: sha1-soqmKIorn8ZRA1x3EfZathkDMaY=}
+    dev: false
 
   /lodash.debounce/4.0.8:
     resolution: {integrity: sha1-gteb/zCmfEAF/9XiUVMArZyk168=}
@@ -5708,13 +5720,6 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
-    dev: true
-
-  /node-html-parser/5.2.0:
-    resolution: {integrity: sha512-fmiwLfQu+J2A0zjwSEkztSHexAf5qq/WoiL/Hgo1K7JpfEP+OGWY5maG0kGaM+IFVdixF/1QbyXaQ3h4cGfeLw==}
-    dependencies:
-      css-select: 4.2.1
-      he: 1.2.0
     dev: true
 
   /node-int64/0.4.0:
@@ -6149,6 +6154,7 @@ packages:
       postcss: ^8.1.0
     dependencies:
       postcss: 8.4.5
+    dev: false
 
   /postcss-modules-local-by-default/4.0.0_postcss@8.4.5:
     resolution: {integrity: sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==}
@@ -6160,6 +6166,7 @@ packages:
       postcss: 8.4.5
       postcss-selector-parser: 6.0.9
       postcss-value-parser: 4.2.0
+    dev: false
 
   /postcss-modules-scope/3.0.0_postcss@8.4.5:
     resolution: {integrity: sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==}
@@ -6169,6 +6176,7 @@ packages:
     dependencies:
       postcss: 8.4.5
       postcss-selector-parser: 6.0.9
+    dev: false
 
   /postcss-modules-values/4.0.0_postcss@8.4.5:
     resolution: {integrity: sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==}
@@ -6178,6 +6186,7 @@ packages:
     dependencies:
       icss-utils: 5.1.0_postcss@8.4.5
       postcss: 8.4.5
+    dev: false
 
   /postcss-modules/4.3.0_postcss@8.4.5:
     resolution: {integrity: sha512-zoUttLDSsbWDinJM9jH37o7hulLRyEgH6fZm2PchxN7AZ8rkdWiALyNhnQ7+jg7cX9f10m6y5VhHsrjO0Mf/DA==}
@@ -6193,6 +6202,7 @@ packages:
       postcss-modules-scope: 3.0.0_postcss@8.4.5
       postcss-modules-values: 4.0.0_postcss@8.4.5
       string-hash: 1.1.3
+    dev: false
 
   /postcss-resolve-nested-selector/0.1.1:
     resolution: {integrity: sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4=}
@@ -6464,10 +6474,6 @@ packages:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
     dev: true
 
-  /react-property/2.0.0:
-    resolution: {integrity: sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw==}
-    dev: true
-
   /react/17.0.2:
     resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}
     engines: {node: '>=0.10.0'}
@@ -6686,6 +6692,7 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
+    dev: false
 
   /run-parallel/1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -6937,31 +6944,6 @@ packages:
       is-fullwidth-code-point: 4.0.0
     dev: true
 
-  /slinkity/0.4.4_c1fe87f73d70d8e087787d786e9215f3:
-    resolution: {integrity: sha512-yYKIb6oxqjaOzO9h2rPMvhHCb82ZKySh2WpfWcWO3ZPZjKJcUAjV4dik2OE1ieeN3JQAqzMmYAx2y77Zl/2uWA==}
-    engines: {node: '>=14'}
-    hasBin: true
-    peerDependencies:
-      '@11ty/eleventy': ^1.0.0-beta.3
-    dependencies:
-      '@11ty/eleventy': 1.0.0
-      commander: 5.1.0
-      esbuild: 0.12.29
-      esbuild-css-modules-plugin: 2.1.1
-      fs-extra: 10.0.0
-      glob: 7.2.0
-      html-react-parser: 1.4.5_react@17.0.2
-      javascript-stringify: 2.1.0
-      node-html-parser: 5.2.0
-      require-from-string: 2.0.2
-      sass: 1.49.0
-      vite: 2.7.13_sass@1.49.0
-    transitivePeerDependencies:
-      - less
-      - react
-      - stylus
-    dev: true
-
   /slugify/1.6.5:
     resolution: {integrity: sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ==}
     engines: {node: '>=8.0.0'}
@@ -7128,6 +7110,7 @@ packages:
 
   /string-hash/1.1.3:
     resolution: {integrity: sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=}
+    dev: false
 
   /string-length/4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
@@ -7245,18 +7228,6 @@ packages:
 
   /style-search/0.1.0:
     resolution: {integrity: sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=}
-    dev: true
-
-  /style-to-js/1.1.0:
-    resolution: {integrity: sha512-1OqefPDxGrlMwcbfpsTVRyzwdhr4W0uxYQzeA2F1CBc8WG04udg2+ybRnvh3XYL4TdHQrCahLtax2jc8xaE6rA==}
-    dependencies:
-      style-to-object: 0.3.0
-    dev: true
-
-  /style-to-object/0.3.0:
-    resolution: {integrity: sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==}
-    dependencies:
-      inline-style-parser: 0.1.1
     dev: true
 
   /stylelint-config-recommended-scss/5.0.2_stylelint@14.3.0:
@@ -7536,6 +7507,7 @@ packages:
     engines: {node: '>=8.17.0'}
     dependencies:
       rimraf: 3.0.2
+    dev: false
 
   /tmpl/1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
@@ -7714,6 +7686,7 @@ packages:
   /universalify/2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
+    dev: false
 
   /unpipe/1.0.0:
     resolution: {integrity: sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=}
@@ -7782,6 +7755,7 @@ packages:
       sass: 1.49.0
     optionalDependencies:
       fsevents: 2.3.2
+    dev: false
 
   /void-elements/3.1.0:
     resolution: {integrity: sha1-YU9/v42AHwu18GYfWy9XhXUOTwk=}

--- a/www/package.json
+++ b/www/package.json
@@ -12,7 +12,7 @@
   "author": "Ben Holmes",
   "license": "MIT",
   "devDependencies": {
-    "@11ty/eleventy": "^1.0.0-beta.9",
+    "@11ty/eleventy": "^1.0.0",
     "@11ty/eleventy-cache-assets": "^2.3.0",
     "@11ty/eleventy-plugin-syntaxhighlight": "^3.1.2",
     "js-yaml": "^3.14.1",
@@ -20,6 +20,6 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "sass": "^1.42.1",
-    "slinkity": "^0.4.2"
+    "slinkity": "*"
   }
 }

--- a/www/package.json
+++ b/www/package.json
@@ -20,6 +20,6 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "sass": "^1.42.1",
-    "slinkity": "*"
+    "slinkity": "workspace:*"
   }
 }


### PR DESCRIPTION
Resolves #171 

## What changed?
- Update `create-slinkity` to generate our new `component` shortcode
- Update all renderer `client.js` files to properly slot in children
- Introduce a paired shortcode under `addComponentShortcodes` for children: `slottedComponent`
- Update our docs to use Slinkity version from workspace and 11ty 1.0 (for testing purposes)