### PR TITLE
Docs: Table of Contents

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,7 @@ importers:
       '@11ty/eleventy': ^1.0.0-beta.9
       '@11ty/eleventy-cache-assets': ^2.3.0
       '@11ty/eleventy-plugin-syntaxhighlight': ^3.1.2
+      eleventy-plugin-nesting-toc: ^1.3.0
       js-yaml: ^3.14.1
       markdown-it-anchor: ^8.3.1
       react: ^17.0.2
@@ -116,6 +117,7 @@ importers:
       '@11ty/eleventy': 1.0.0
       '@11ty/eleventy-cache-assets': 2.3.0
       '@11ty/eleventy-plugin-syntaxhighlight': 3.2.2
+      eleventy-plugin-nesting-toc: 1.3.0
       js-yaml: 3.14.1
       markdown-it-anchor: 8.4.1
       react: 17.0.2
@@ -2550,6 +2552,29 @@ packages:
       is-regex: 1.1.4
     dev: true
 
+  /cheerio-select/1.5.0:
+    resolution: {integrity: sha512-qocaHPv5ypefh6YNxvnbABM07KMxExbtbfuJoIie3iZXX1ERwYmJcIiRrr9H05ucQP1k28dav8rpdDgjQd8drg==}
+    dependencies:
+      css-select: 4.2.1
+      css-what: 5.1.0
+      domelementtype: 2.2.0
+      domhandler: 4.3.0
+      domutils: 2.8.0
+    dev: true
+
+  /cheerio/1.0.0-rc.10:
+    resolution: {integrity: sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==}
+    engines: {node: '>= 6'}
+    dependencies:
+      cheerio-select: 1.5.0
+      dom-serializer: 1.3.2
+      domhandler: 4.3.0
+      htmlparser2: 6.1.0
+      parse5: 6.0.1
+      parse5-htmlparser2-tree-adapter: 6.0.1
+      tslib: 2.3.1
+    dev: true
+
   /chokidar/3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
     engines: {node: '>= 8.10.0'}
@@ -3090,6 +3115,12 @@ packages:
 
   /electron-to-chromium/1.4.53:
     resolution: {integrity: sha512-rFveSKQczlcav+H3zkKqykU6ANseFwXwkl855jOIap5/0gnEcuIhv2ecz6aoTrXavF6I/CEBeRnBnkB51k06ew==}
+    dev: true
+
+  /eleventy-plugin-nesting-toc/1.3.0:
+    resolution: {integrity: sha512-WZzVkz28nw3A0DpJFQWXZzQxniyjvOZKxVix5x7WVAS0H1OD1hYJbR0go/Lr1kK2SrmxfbsUHUlekR+mQPvqMA==}
+    dependencies:
+      cheerio: 1.0.0-rc.10
     dev: true
 
   /emittery/0.8.1:
@@ -3760,18 +3791,6 @@ packages:
       debug: 4.3.2
     dev: true
 
-  /follow-redirects/1.14.7_debug@4.3.3:
-    resolution: {integrity: sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dependencies:
-      debug: 4.3.3
-    dev: true
-
   /form-data/3.0.1:
     resolution: {integrity: sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==}
     engines: {node: '>= 6'}
@@ -4087,6 +4106,15 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /htmlparser2/6.1.0:
+    resolution: {integrity: sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==}
+    dependencies:
+      domelementtype: 2.2.0
+      domhandler: 4.3.0
+      domutils: 2.8.0
+      entities: 2.2.0
+    dev: true
+
   /htmlparser2/7.2.0:
     resolution: {integrity: sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==}
     dependencies:
@@ -4143,7 +4171,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.14.7_debug@4.3.3
+      follow-redirects: 1.14.7_debug@4.3.2
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -5902,6 +5930,12 @@ packages:
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+    dev: true
+
+  /parse5-htmlparser2-tree-adapter/6.0.1:
+    resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
+    dependencies:
+      parse5: 6.0.1
     dev: true
 
   /parse5/6.0.1:

--- a/www/.eleventy.js
+++ b/www/.eleventy.js
@@ -30,7 +30,6 @@ module.exports = function config(eleventyConfig) {
   }
   const markdownConfigured = markdownIt({ html: true }).use(markdownItAnchor, markdownItAnchorSettings)
 
-  eleventyConfig.addFilter('markdown', value => markdownConfigured.render(value));
   eleventyConfig.addPlugin(toc, {tags: ['h2', 'h3', 'h4', 'h5', 'h6']})
 
   eleventyConfig.addShortcode('featureProgress', convertEmojiToAccessibleProgress)

--- a/www/.eleventy.js
+++ b/www/.eleventy.js
@@ -2,6 +2,7 @@ const syntaxHighlight = require('@11ty/eleventy-plugin-syntaxhighlight')
 const yaml = require('js-yaml')
 const markdownIt = require('markdown-it')
 const markdownItAnchor = require('markdown-it-anchor')
+const toc = require('eleventy-plugin-nesting-toc')
 const convertEmojiToAccessibleProgress = require('./src/utils/feature-progress-shortcode')
 
 module.exports = function config(eleventyConfig) {
@@ -13,7 +14,7 @@ module.exports = function config(eleventyConfig) {
       symbol: '🔗'
   })
   const markdownItAnchorSettings = {
-    level: [2],
+    level: [2,3],
     permalink (slug, opts, state, idx) {
       // this is necessary to wrap the headings in an element
       state.tokens.splice(idx, 0, Object.assign(new state.Token('div_open', 'div', 1), {
@@ -28,6 +29,9 @@ module.exports = function config(eleventyConfig) {
     }
   }
   const markdownConfigured = markdownIt({ html: true }).use(markdownItAnchor, markdownItAnchorSettings)
+
+  eleventyConfig.addFilter('markdown', value => markdownConfigured.render(value));
+  eleventyConfig.addPlugin(toc, {tags: ['h2', 'h3', 'h4', 'h5', 'h6']})
 
   eleventyConfig.addShortcode('featureProgress', convertEmojiToAccessibleProgress)
 

--- a/www/package.json
+++ b/www/package.json
@@ -15,6 +15,7 @@
     "@11ty/eleventy": "^1.0.0-beta.9",
     "@11ty/eleventy-cache-assets": "^2.3.0",
     "@11ty/eleventy-plugin-syntaxhighlight": "^3.1.2",
+    "eleventy-plugin-nesting-toc": "^1.3.0",
     "js-yaml": "^3.14.1",
     "markdown-it-anchor": "^8.3.1",
     "react": "^17.0.2",

--- a/www/src/_includes/toc.njk
+++ b/www/src/_includes/toc.njk
@@ -1,0 +1,3 @@
+<p class="toc__label">On this page</p>
+<a class="toc__overview-link" href="#main-content">Overview</a>
+{{ content | toc | safe }}

--- a/www/src/_layouts/docs.njk
+++ b/www/src/_layouts/docs.njk
@@ -54,8 +54,14 @@ styles:
         </ul>
       </li>
     </ul>
+    <div class="docs__toc  toc-container">
+      {%- include 'toc.njk' -%}
+    </div>
     <article class="docs__container__content" id="main-content" tabindex="-1">
       <h1>{{ title }}</h1>
+      <div class="docs__container__content-toc  toc-container">
+        {%- include 'toc.njk' -%}
+      </div>
       {{ content | safe }}
     </article>
   </main>

--- a/www/styles/_generic.scss
+++ b/www/styles/_generic.scss
@@ -40,7 +40,7 @@
   --gradient-slinkity: hsl(var(--color-hs-accent) 50%), hsl(var(--color-hs-highlight) 50%);
 
   // misc
-  --content-max-width: 1024px;
+  --content-max-width: 1200px;
   --rounded-corners: 5px;
   --shadow-heavy: 0 4px 14px #000;
   --default-padding: clamp(1em, 5vh, 3em) clamp(1em, 4vw, 2em);

--- a/www/styles/_settings.scss
+++ b/www/styles/_settings.scss
@@ -1,5 +1,5 @@
 $breakpoints: (
   "mobile": 500px,
   "tablet": 768px,
-  "wrapper": 1024px
+  "wrapper": 1200px
 );

--- a/www/styles/_tools.scss
+++ b/www/styles/_tools.scss
@@ -72,13 +72,13 @@
   border-radius: var(--rounded-corners);
   box-shadow: var(--shadow-heavy);
   background-color: var(--color-primary-8);
+  @include gradient-links;
 
   > .heading-wrapper:first-child {
     > * {
       margin-block-start: 0;
     }
   }
-  @include gradient-links;
 }
 
 @mixin underline-link-in-forced-colors {

--- a/www/styles/chunks/_toc.scss
+++ b/www/styles/chunks/_toc.scss
@@ -1,0 +1,76 @@
+.toc {
+  &-container {
+    --gap: 0.25em;
+    --spacing: 0.75em;
+    --border-width: 2px;
+    --border-style: var(--border-width) solid var(--color-primary-6);
+
+    :is(a,a:visited) {
+      display: block;
+      text-decoration: none;
+
+      &:not(:focus, :hover) {
+        color: var(--link-color, #fff);
+      }
+    }
+  }
+
+  &__label {
+    color: var(--color-primary-2);
+    font-family: var(--pro-hacker-font);
+    text-transform: uppercase;
+    letter-spacing: 0.15em;
+    font-size: 0.75em;
+    margin-block-start: 0;
+    margin-block-end: 1em;
+  }
+
+  &__overview-link {
+    display: block;
+    margin-inline-start: calc(var(--spacing) + var(--border-width));
+    position: relative;
+
+    &::before {
+      content: "";
+      position: absolute;
+      height: 100%;
+      left: calc((var(--spacing) + var(--border-width)) * -1);
+      top: 0;
+      border-inline-start: var(--border-style);
+    }
+  }
+
+  ol {
+    padding-inline-start: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap);
+  }
+
+  li {
+    margin-block-end: 0;
+    padding-inline-start: var(--spacing);
+    line-height: 1.25;
+
+    &::marker {
+      font-size: 0;
+    }
+  }
+
+  & > ol {
+    margin-block: 0;
+    border-inline-start: var(--border-style);
+
+    > li {
+      > ol {
+        margin-block-start: var(--spacing);
+        font-size: 0.9rem;
+
+        a,
+        a:visited {
+          --link-color: var(--color-primary-1);
+        }
+      }
+    }
+  }
+}

--- a/www/styles/docs.scss
+++ b/www/styles/docs.scss
@@ -2,6 +2,7 @@
 
 .docs {
   --nav-width: 240px;
+  --toc-width: 270px;
   --nav-height: 4rem;
   --site-gap: clamp(2em, 4.25vmax, 4em);
 
@@ -218,6 +219,21 @@
     }
   }
 
+  // this TOC is shown on desktop
+  &__toc {
+    @include content-card;
+    display: none;
+    @media (min-width: breakpoint(wrapper)) {
+      width: 100%;
+      display: block;
+      grid-column: toc-start / toc-end;
+      margin-block-start: 0;
+      padding: 1rem;
+      position: sticky;
+      top: var(--site-gap);
+    }
+  }
+
   // Docs Page Content
   &__container {
     max-width: var(--content-max-width);
@@ -226,9 +242,13 @@
     display: grid;
     grid-template-columns: 1fr;
     align-items: flex-start;
-    gap: var(--site-gap);
+    gap: calc(var(--site-gap) / 2);
     @media (min-width: breakpoint(tablet)) {
       grid-template-columns: [side-start] var(--nav-width) [side-end content-start] 1fr [content-end];
+    }
+    @media (min-width: breakpoint(wrapper)) {
+      grid-template-columns: [side-start] var(--nav-width) [side-end content-start] 1fr [content-end toc-start] var(--toc-width) [toc-end];
+      grid-auto-flow: dense;
     }
 
     &__content {
@@ -236,10 +256,35 @@
       overflow: auto;
       max-width: 100%;
       margin: 0;
+      @media (min-width: breakpoint(tablet)) {
+        grid-column: content-start / content-end;
+      }
+      @media (forced-colors: active) {
+        padding-block-start: 0;
+      }
+
+      // this TOC is shown on smaller screens
+      &-toc {
+        --bg: hsl(var(--color-hs-primary) calc(var(--color-weight-7) - 6.5%));
+        padding: calc(var(--spacing) * 1.5);
+        background-color: var(--bg);
+        border-radius: 5px;
+        @media (min-width: breakpoint(wrapper)) {
+          display: none;
+        }
+
+        & + * {
+          margin-block: 2.5em;
+        }
+      }
 
       :where(h1) {
         margin-block-start: 0;
         font-size: 2.25em;
+
+        + * {
+          margin-block-start: 1.5em;
+        }
       }
 
       :where(pre) {
@@ -295,12 +340,6 @@
             padding-block-end: 1em;
           }
         }
-      }
-      @media (min-width: breakpoint(tablet)) {
-        grid-column: content-start / content-end;
-      }
-      @media (forced-colors: active) {
-        padding-block-start: 0;
       }
     }
   }

--- a/www/styles/styles.scss
+++ b/www/styles/styles.scss
@@ -9,3 +9,4 @@
 @use "chunks/heading-wrapper";
 @use "chunks/external-link";
 @use "chunks/site-footer";
+@use "chunks/toc";


### PR DESCRIPTION
closes #104 

- Adds a TOC!
- Increases the wrapper width to 1200px from previously 1024px

The plugin used provides a filter that runs over the entirety of the content and includes all headlines that have an id set. The current configuration will include headlines from `<h1>` to `<h6>`, _but_ we currently only run `markdown-it-anchor` on `<h2>`& `<h3>`. This means, that if we wanted to include deeper levels of headlines, we'd just have to change the `markdown-it-anchor` config to include more levels. All of this is done comfortably from `.eleventy.js`.

Here are some screenshots:
![Screenshot 2022-02-17 at 00 02 54](https://user-images.githubusercontent.com/4201323/154372235-cc72817f-714d-458c-ad11-e98eb7d5218c.png)
![Screenshot 2022-02-17 at 00 03 06](https://user-images.githubusercontent.com/4201323/154372240-0c7d484f-f988-458a-98eb-c1057bfa8265.png)
![Screenshot 2022-02-17 at 00 03 19](https://user-images.githubusercontent.com/4201323/154372243-563d7a55-55a3-4eac-8a87-fd3cfb450254.png)

We don't have a design for this, so this was done on the fly. Any visual feedback is _very_ welcome.