### PR TITLE
Fix: instructional logs to upgrade "render" -> "hydrate"

### DIFF
--- a/packages/slinkity-renderer-react/index.js
+++ b/packages/slinkity-renderer-react/index.js
@@ -1,5 +1,6 @@
 const pkg = require('./package.json')
 const reactPlugin = require('@vitejs/plugin-react')
+const chalk = require('chalk')
 
 const client = `${pkg.name}/client`
 const server = `${pkg.name}/server`
@@ -42,6 +43,14 @@ module.exports = {
       useFormatted11tyData: true,
       async getData(inputPath) {
         const Component = await toCommonJSModule(inputPath)
+        console.log(Object.keys(Component))
+        if (Component.getProps !== undefined) {
+          console.log(
+            chalk.yellow(
+              `[Warning] The "getProps" function is no longer supported as of v0.6! If you intended to use "getProps" to generate props for your component page "${inputPath}," try using "hydrate.props(...)" instead. See our docs for more: https://slinkity.dev/docs/component-pages-layouts`,
+            ),
+          )
+        }
         return Component.frontMatter
       },
     }

--- a/packages/slinkity-renderer-react/index.js
+++ b/packages/slinkity-renderer-react/index.js
@@ -43,7 +43,6 @@ module.exports = {
       useFormatted11tyData: true,
       async getData(inputPath) {
         const Component = await toCommonJSModule(inputPath)
-        console.log(Object.keys(Component))
         if (Component.getProps !== undefined) {
           console.log(
             chalk.yellow(

--- a/packages/slinkity-renderer-react/index.js
+++ b/packages/slinkity-renderer-react/index.js
@@ -47,7 +47,7 @@ module.exports = {
         if (Component.getProps !== undefined) {
           console.log(
             chalk.yellow(
-              `[Warning] The "getProps" function is no longer supported as of v0.6! If you intended to use "getProps" to generate props for your component page "${inputPath}," try using "hydrate.props(...)" instead. See our docs for more: https://slinkity.dev/docs/component-pages-layouts`,
+              `[Warning] The "getProps" function is no longer supported as of v0.6! If you intended to use "getProps" to generate props for your component page "${inputPath}," try using "hydrate.props(...)" instead. You can also avoid hydrating your page to omit "getProps" entirely. See our docs for more: https://slinkity.dev/docs/component-pages-layouts`,
             ),
           )
         }

--- a/packages/slinkity-renderer-react/index.js
+++ b/packages/slinkity-renderer-react/index.js
@@ -46,7 +46,7 @@ module.exports = {
         if (Component.getProps !== undefined) {
           console.log(
             chalk.yellow(
-              `[Warning] The "getProps" function is no longer supported as of v0.6! If you intended to use "getProps" to generate props for your component page "${inputPath}," try using "hydrate.props(...)" instead. You can also avoid hydrating your page to omit "getProps" entirely. See our docs for more: https://slinkity.dev/docs/component-pages-layouts`,
+              `[Warning] The "getProps" function is no longer supported as of v0.6! If you intended to use "getProps" to generate props for "${inputPath}," try using "hydrate.props(...)" instead. You can also avoid hydrating your page to omit "getProps" entirely. See our docs for more: https://slinkity.dev/docs/component-pages-layouts`,
             ),
           )
         }

--- a/packages/slinkity-renderer-react/package.json
+++ b/packages/slinkity-renderer-react/package.json
@@ -24,6 +24,7 @@
     "@vitejs/plugin-react": "^1.2.0"
   },
   "devDependencies": {
+    "chalk": "4.1.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/packages/slinkity/eleventyConfig/addComponentPages.js
+++ b/packages/slinkity/eleventyConfig/addComponentPages.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const toFormattedDataForProps = require('../utils/toFormattedDataForProps')
 const { toSSRComment } = require('../utils/consts')
+const { log } = require('../utils/logger')
 
 /**
  * @typedef AddComponentPagesParams
@@ -85,6 +86,13 @@ module.exports = async function addComponentPages({
             // if there's no "props" function, but we *do* hydrate the page,
             // don't pass any props
             props = {}
+          }
+
+          if (data.render !== undefined) {
+            log({
+              type: 'warning',
+              message: `The "render" prop no longer affects hydration as of v0.6! If you intended to use "render" to hydrate the component page at "${inputPath}," try using "hydrate" instead. See our docs for more: https://slinkity.dev/docs/component-pages-layouts`,
+            })
           }
 
           const id = componentAttrStore.push({

--- a/packages/slinkity/eleventyConfig/addComponentPages.js
+++ b/packages/slinkity/eleventyConfig/addComponentPages.js
@@ -91,7 +91,7 @@ module.exports = async function addComponentPages({
           if (data.render !== undefined) {
             log({
               type: 'warning',
-              message: `The "render" prop no longer affects hydration as of v0.6! If you intended to use "render" to hydrate the component page at "${inputPath}," try using "hydrate" instead. See our docs for more: https://slinkity.dev/docs/component-pages-layouts`,
+              message: `The "render" prop no longer affects hydration as of v0.6! If you intended to use "render" to hydrate "${inputPath}," try using "hydrate" instead. Also note that pages are no longer hydrated by default. See our docs for more: https://slinkity.dev/docs/component-pages-layouts`,
             })
           }
 

--- a/packages/slinkity/eleventyConfig/addComponentShortcodes.js
+++ b/packages/slinkity/eleventyConfig/addComponentShortcodes.js
@@ -146,6 +146,13 @@ See our docs for more: https://slinkity.dev/docs/component-shortcodes`)
   // eslint-disable-next-line no-unused-vars
   const { __keywords, ...restOfProps } = props
 
+  if (restOfProps.render !== undefined) {
+    log({
+      type: 'warning',
+      errorMsg: `The "render" prop no longer affects hydration as of v0.6! If you intended to use "render" to hydrate the component "${componentPath}," try using "hydrate" instead. See our docs for more: https://slinkity.dev/docs/component-shortcodes`,
+    })
+  }
+
   /** @type {{ hydrate: import('../cli/types').HydrationMode }} */
   const { hydrate = 'none' } = props
   return {

--- a/packages/slinkity/eleventyConfig/addComponentShortcodes.js
+++ b/packages/slinkity/eleventyConfig/addComponentShortcodes.js
@@ -149,7 +149,7 @@ See our docs for more: https://slinkity.dev/docs/component-shortcodes`)
   if (restOfProps.render !== undefined) {
     log({
       type: 'warning',
-      errorMsg: `The "render" prop no longer affects hydration as of v0.6! If you intended to use "render" to hydrate the component "${componentPath}," try using "hydrate" instead. See our docs for more: https://slinkity.dev/docs/component-shortcodes`,
+      message: `The "render" prop no longer affects hydration as of v0.6! If you intended to use "render" to hydrate "${componentPath}," try using "hydrate" instead. Also note that components are no longer hydrated by default. See our docs for more: https://slinkity.dev/docs/component-shortcodes`,
     })
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,11 +98,13 @@ importers:
   packages/slinkity-renderer-react:
     specifiers:
       '@vitejs/plugin-react': ^1.2.0
+      chalk: 4.1.2
       react: ^17.0.2
       react-dom: ^17.0.2
     dependencies:
       '@vitejs/plugin-react': 1.2.0
     devDependencies:
+      chalk: 4.1.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
 


### PR DESCRIPTION
- add warnings when using the "render" prop
- add warning when using "getProps" on React component pages