### PR TITLE
Fix: expose shortcodes and filters via `__functions`

### DIFF
--- a/packages/slinkity-renderer-react/StaticHtml.js
+++ b/packages/slinkity-renderer-react/StaticHtml.js
@@ -13,17 +13,10 @@ import { createElement as h } from 'react'
  */
 const StaticHtml = ({ value }) => {
   if (!value) return null
-  return h('slinkity-fragment', {
+  return h('astro-fragment', {
     suppressHydrationWarning: true,
     dangerouslySetInnerHTML: { __html: value },
   })
-}
-
-export function toComponentByShortcode({ unnamedArgs, shortcode }) {
-  return (namedArgs) => {
-    const value = shortcode(...unnamedArgs, namedArgs)
-    return h(StaticHtml, { value })
-  }
 }
 
 /**

--- a/packages/slinkity-renderer-react/index.js
+++ b/packages/slinkity-renderer-react/index.js
@@ -4,7 +4,6 @@ const chalk = require('chalk')
 
 const client = `${pkg.name}/client`
 const server = `${pkg.name}/server`
-const toComponentByShortcode = `${pkg.name}/StaticHtml`
 
 /** @type {import('../slinkity').Renderer} */
 module.exports = {
@@ -12,7 +11,6 @@ module.exports = {
   extensions: ['jsx', 'tsx'],
   client,
   server,
-  toComponentByShortcode,
   injectImportedStyles: true,
   viteConfig() {
     return {

--- a/packages/slinkity-renderer-react/package.json
+++ b/packages/slinkity-renderer-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slinkity/renderer-react",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "React component renderer for the legendary 11ty tool, Slinkity",
   "main": "index.js",
   "files": [

--- a/packages/slinkity-renderer-vue/StaticHtml.js
+++ b/packages/slinkity-renderer-vue/StaticHtml.js
@@ -15,23 +15,9 @@ const StaticHtml = defineComponent({
   },
   setup({ value }) {
     if (!value) return () => null
-    return () => h('slinkity-fragment', { innerHTML: value })
+    return () => h('astro-fragment', { innerHTML: value })
   },
 })
-
-export function toComponentByShortcode({ unnamedArgs, shortcode }) {
-  return defineComponent({
-    props: {
-      hydrate: String,
-      // TODO: support any props
-    },
-    setup(namedArgs) {
-      if (!namedArgs) return () => null
-      const innerHTML = shortcode(...unnamedArgs, namedArgs)
-      return () => h('slinkity-fragment', { innerHTML })
-    },
-  })
-}
 
 /**
  * Other frameworks have `shouldComponentUpdate` in order to signal

--- a/packages/slinkity-renderer-vue/index.js
+++ b/packages/slinkity-renderer-vue/index.js
@@ -3,7 +3,6 @@ const vue = require('@vitejs/plugin-vue')
 
 const client = `${pkg.name}/client`
 const server = `${pkg.name}/server`
-const toComponentByShortcode = `${pkg.name}/StaticHtml`
 
 /** @type {import('../slinkity').Renderer} */
 module.exports = {
@@ -11,7 +10,6 @@ module.exports = {
   extensions: ['vue'],
   client,
   server,
-  toComponentByShortcode,
   injectImportedStyles: true,
   viteConfig() {
     return {

--- a/packages/slinkity-renderer-vue/package.json
+++ b/packages/slinkity-renderer-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slinkity/renderer-vue",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Vue component renderer for the legendary 11ty tool, Slinkity",
   "main": "index.js",
   "files": [

--- a/packages/slinkity-renderer-vue/server.js
+++ b/packages/slinkity-renderer-vue/server.js
@@ -8,10 +8,7 @@ export default async function server({ toCommonJSModule, componentPath, props, c
   if (children) {
     slots.default = () => h(StaticHtml, { value: children })
   }
-  const shortcodes = Component.shortcodes?.(props.__slinkity?.shortcodes ?? {}) ?? {}
-  const app = createSSRApp({
-    render: () => h({ ...Component, components: shortcodes }, props, slots),
-  })
+  const app = createSSRApp({ render: () => h(Component, props, slots) })
   const html = await renderToString(app)
   return { html }
 }

--- a/packages/slinkity/cli/types.d.ts
+++ b/packages/slinkity/cli/types.d.ts
@@ -53,8 +53,6 @@ export type Renderer = {
   client: string;
   /** path to module used for server rendering - NodeJS code */
   server: string;
-  /** path to module used to wrap shortcode HTML element in a component - NodeJS code */
-  toComponentByShortcode: string;
   /** inject CSS imported by component module into document head */
   injectImportedStyles: boolean;
   /** config to append to Vite server and production builds */

--- a/packages/slinkity/eleventyConfig/addComponentPages.js
+++ b/packages/slinkity/eleventyConfig/addComponentPages.js
@@ -34,9 +34,10 @@ module.exports = async function addComponentPages({
       },
       compileOptions: {
         permalink() {
+          const __functions = this
           return function render({ permalink, ...data }) {
             if (typeof permalink === 'function') {
-              return permalink(data)
+              return permalink({ ...data, __functions })
             } else {
               return permalink
             }

--- a/packages/slinkity/eleventyConfig/applyViteHtmlTransform.js
+++ b/packages/slinkity/eleventyConfig/applyViteHtmlTransform.js
@@ -48,34 +48,10 @@ async function handleSSRComments({
       const { __importedStyles } = await viteSSR.toCommonJSModule(componentPath)
       __importedStyles.forEach((importedStyle) => importedStyles.add(importedStyle))
     }
-    let shortcodes = props.__slinkity?.shortcodes
-    let propsWithShortcodes = props
-    if (typeof shortcodes === 'object' && hydrate === 'none') {
-      try {
-        const { toComponentByShortcode } = await viteSSR.toCommonJSModule(
-          renderer.toComponentByShortcode,
-        )
-        propsWithShortcodes = {
-          ...props,
-          __slinkity: {
-            ...(props.__slinkity ?? {}),
-            shortcodes: Object.fromEntries(
-              Object.entries(shortcodes).map(([name, shortcode]) => [
-                name,
-                (...unnamedArgs) => toComponentByShortcode({ unnamedArgs, shortcode }),
-              ]),
-            ),
-          },
-        }
-      } catch {
-        // This renderer can't handle shortcodes-as-components.
-        // Do nothing!
-      }
-    }
     const serverRendered = await serverRenderer({
       toCommonJSModule: viteSSR.toCommonJSModule,
       componentPath,
-      props: propsWithShortcodes,
+      props,
       children,
       hydrate,
     })

--- a/packages/slinkity/package.json
+++ b/packages/slinkity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slinkity",
   "description": "To 11ty and beyond! The all-in-one tool for templates where you want them, component frameworks where you need them",
-  "version": "0.6.1-canary.3",
+  "version": "0.6.1-canary.4",
   "license": "MIT",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
This _reverts_ our support for JSX-ified shortcodes as described in #155. This deserves an RFC and further community discussion to land on the right formatting, especially to make these shortcodes-as-components usable across frameworks.

## What's changed?
- revert PR to support shortcodes-as-components
- expose the "raw" filters and shortcodes (11ty's `javascriptFunctions`) via the `__functions` prop
  - expose from dynamic permalink functions
  - expose from `hydrate.props()`
  - expose on non-hydrated component data