### PR TITLE
Fix 0.5.0 error requiring react-dom, react as deps

### DIFF
--- a/packages/slinkity/cli/vite.js
+++ b/packages/slinkity/cli/vite.js
@@ -49,7 +49,7 @@ async function getSharedConfig(eleventyDir) {
         dedupe: ['react', 'react-dom'],
       },
       optimizeDeps: {
-        include: ['react', 'react/jsx-runtime', 'react/jsx-dev-runtime', 'react-dom'],
+        include: ['react', 'react/jsx-runtime', 'react/jsx-dev-runtime', 'react-dom', 'slinkity/client'],
       },
       build: {
         rollupOptions: {
@@ -71,9 +71,7 @@ async function getSharedConfig(eleventyDir) {
       resolve: {
         alias: Object.fromEntries(importAliasesToResolvedPath),
       },
-      optimizeDeps: {
-        include: ['slinkity/client'],
-      },
+      optimizeDeps: {},
     }),
     reactConfig,
   )

--- a/packages/slinkity/cli/vite.js
+++ b/packages/slinkity/cli/vite.js
@@ -49,7 +49,13 @@ async function getSharedConfig(eleventyDir) {
         dedupe: ['react', 'react-dom'],
       },
       optimizeDeps: {
-        include: ['react', 'react/jsx-runtime', 'react/jsx-dev-runtime', 'react-dom', 'slinkity/client'],
+        include: [
+          'react',
+          'react/jsx-runtime',
+          'react/jsx-dev-runtime',
+          'react-dom',
+          'slinkity/client',
+        ],
       },
       build: {
         rollupOptions: {


### PR DESCRIPTION
This should resolve #187 as @Holben888 suggested to try. I'll confirm that this alone actually ends up fixing the issue later today when I get back home, but wanted to get the PR with the fix up ASAP so I don't forget about making this contribution. Thanks Ben for all of your hard work on Slinkity and extremely informative videos that you've made on partial hydration, custom client-side routing without a SPA framework, etc! I really like the approach Slinkity uses and am excited to try and start hacking on the updates to my personal portfolio site that I've been wanting to make for years now 😃 (and from one Ben to another, you've got a solid first name 😎)