### PR TITLE
Docs: quick start updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,24 +35,20 @@ To learn more, and explore adding Slinkity to _existing_ 11ty projects...
 
 This project is still in early alpha, so we have many features soon to come! [This demo](https://www.youtube.com/watch?v=X_zp6CodHjc&t=493s) covers a majority of features we support today. For reference, here's our complete roadmap of current and upcoming features:
 
-| Feature                                                | Status |
-| ------------------------------------------------------ | ------ |
-| CLI to run 11ty and Vite simultaneously                | ✅      |
-| React component pages & layouts                        | ✅      |
-| React component shortcodes                             | ✅      |
-| SCSS and SASS                                          | ✅      |
-| PostCSS config (ex. Tailwind)                          | ✅      |
-| CSS imports via ESM (including CSS modules) *          | ⏺      |
-| Plugin ecosystem for your favorite component framework |
-| (Vue, Svelte, Solid, etc)                              | ⏳      |
-| Eleventy serverless compatibility                      | ❌      |
-| Shared state between component shortcodes              | ❌      |
-| Styled components & Emotion                            | ❌      |
-
-_*CSS imports will work today, but with one caveat: stylesheets will bleed to other routes on your site. We're actively working on a fix!_
+| Feature                                                                               | Status    |
+|---------------------------------------------------------------------------------------|-----------|
+| CLI to run 11ty and Vite simultaneously                                               | ✅         |
+| Plugin ecosystem for your favorite component framework (React, Vue, Svelte, etc)      | ✅         |
+| Component pages                                                                       | ✅         |
+| Component shortcodes                                                                  | ✅         |
+| SCSS and SASS                                                                         | ✅         |
+| PostCSS config (ex. Tailwind)                                                         | ✅         |
+| CSS imports via ESM (including CSS modules)                                           | ✅         |
+| Eleventy serverless compatibility                                                     | ⏳         |
+| Shared state between any component shortcode                                          | ❌         |
+| Styled components & Emotion support                                                   | ❌         |
 
 - ✅ = Ready to use
-- ⏺ = Partial support
 - ⏳ = In progress
 - ❌ = Not started, but on roadmap
 

--- a/packages/slinkity/README.md
+++ b/packages/slinkity/README.md
@@ -35,24 +35,20 @@ To learn more, and explore adding Slinkity to _existing_ 11ty projects...
 
 This project is still in early alpha, so we have many features soon to come! [This demo](https://www.youtube.com/watch?v=X_zp6CodHjc&t=493s) covers a majority of features we support today. For reference, here's our complete roadmap of current and upcoming features:
 
-| Feature                                                | Status |
-| ------------------------------------------------------ | ------ |
-| CLI to run 11ty and Vite simultaneously                | ✅      |
-| React component pages & layouts                        | ✅      |
-| React component shortcodes                             | ✅      |
-| SCSS and SASS                                          | ✅      |
-| PostCSS config (ex. Tailwind)                          | ✅      |
-| CSS imports via ESM (including CSS modules) *          | ⏺      |
-| Plugin ecosystem for your favorite component framework |
-| (Vue, Svelte, Solid, etc)                              | ⏳      |
-| Eleventy serverless compatibility                      | ❌      |
-| Shared state between component shortcodes              | ❌      |
-| Styled components & Emotion                            | ❌      |
-
-_*CSS imports will work today, but with one caveat: stylesheets will bleed to other routes on your site. We're actively working on a fix!_
+| Feature                                                                               | Status    |
+|---------------------------------------------------------------------------------------|-----------|
+| CLI to run 11ty and Vite simultaneously                                               | ✅         |
+| Plugin ecosystem for your favorite component framework (React, Vue, Svelte, etc)      | ✅         |
+| Component pages                                                                       | ✅         |
+| Component shortcodes                                                                  | ✅         |
+| SCSS and SASS                                                                         | ✅         |
+| PostCSS config (ex. Tailwind)                                                         | ✅         |
+| CSS imports via ESM (including CSS modules)                                           | ✅         |
+| Eleventy serverless compatibility                                                     | ⏳         |
+| Shared state between any component shortcode                                          | ❌         |
+| Styled components & Emotion support                                                   | ❌         |
 
 - ✅ = Ready to use
-- ⏺ = Partial support
 - ⏳ = In progress
 - ❌ = Not started, but on roadmap
 

--- a/packages/slinkity/package.json
+++ b/packages/slinkity/package.json
@@ -73,7 +73,7 @@
     "vite": "^2.7.10"
   },
   "peerDependencies": {
-    "@11ty/eleventy": "^1.0.0-beta.3"
+    "@11ty/eleventy": "^1.0.0"
   },
   "devDependencies": {
     "browser-sync": "^2.27.5",

--- a/www/src/_includes/value-props.md
+++ b/www/src/_includes/value-props.md
@@ -1,6 +1,6 @@
 Slinkity is the simplest way to handle styles and component frameworks on your 11ty site. Once installed, this:
 
-- 🚀 **Unlocks component frameworks** like React for writing page templates and layout templates. Turn an existing `.html` or `.liquid` file into a `.jsx` file, and you're off to the componentized races.
-- 🔖 **Includes powerful shortcodes** to insert components into existing pages. Add a line like this to your markdown, HTML, Nunjucks, etc, and watch the magic happen: {% raw %}`{% react 'path/to/component' %}`{% endraw %}
+- 🚀 **Unlocks component frameworks** like React, Vue, and Svelte for writing page templates. Turn an existing `.html` or `.liquid` file into a `.jsx|tsx|vue|svelte` file, and you're off to the componentized races.
+- 🔖 **Includes powerful shortcodes** to insert components into existing pages. Add a line like this to your markdown, HTML, Nunjucks, etc, and watch the magic happen: {% raw %}`{% component 'path/to/Component.*' %}`{% endraw %}
 - 💧 **Hydrates these components** when and how you want. Use component frameworks as a static template to start, and opt-in to shipping JS as needed with our [partial hydration helpers](/docs/partial-hydration).
 - 💅 **Bundles all your resources** with the power of Vite. Use your favorite CSS preprocessor, JS minifier, and more with minimal config.

--- a/www/src/docs/index.md
+++ b/www/src/docs/index.md
@@ -28,20 +28,17 @@ This project is still in early alpha, so we have many features soon to come! [Th
 | Feature                                                                               | Status                    |
 |---------------------------------------------------------------------------------------|---------------------------|
 | CLI to run 11ty and Vite simultaneously                                               | {% featureProgress '✅' %} |
-| React component pages & layouts                                                       | {% featureProgress '✅' %} |
-| React component shortcodes                                                            | {% featureProgress '✅' %} |
+| Plugin ecosystem for your favorite component framework<br />(React, Vue, Svelte, etc) | {% featureProgress '✅' %} |
+| Component pages                                                                       | {% featureProgress '✅' %} |
+| Component shortcodes                                                                  | {% featureProgress '✅' %} |
 | SCSS and SASS                                                                         | {% featureProgress '✅' %} |
 | PostCSS config (ex. Tailwind)                                                         | {% featureProgress '✅' %} |
-| CSS imports via ESM (including CSS modules) *                                         | {% featureProgress '⏺' %} |
-| Plugin ecosystem for your favorite component framework<br />(Vue, Svelte, Solid, etc) | {% featureProgress '⏳' %} |
-| Eleventy serverless compatibility                                                     | {% featureProgress '❌' %} |
-| Shared state between component shortcodes                                             | {% featureProgress '❌' %} |
-| Styled components & Emotion                                                           | {% featureProgress '❌' %} |
-
-_*CSS imports will work today, but with one caveat: stylesheets will bleed to other routes on your site. We're actively working on a fix!_
+| CSS imports via ESM (including CSS modules)                                           | {% featureProgress '✅' %} |
+| Eleventy serverless compatibility                                                     | {% featureProgress '⏳' %} |
+| Shared state between any component shortcode                                          | {% featureProgress '❌' %} |
+| Styled components & Emotion support                                                   | {% featureProgress '❌' %} |
 
 - ✅ = Ready to use
-- ⏺ = Partial support
 - ⏳ = In progress
 - ❌ = Not started, but on roadmap
 

--- a/www/src/docs/quick-start.md
+++ b/www/src/docs/quick-start.md
@@ -39,7 +39,7 @@ npx slinkity --serve --incremental
 This command will:
 
 1. Start up [11ty in `--watch` mode](https://www.11ty.dev/docs/usage/#re-run-eleventy-when-you-save) to listen for file changes
-2. Start up [a Vite server](https://vitejs.dev/guide/#index-html-and-project-root) pointed at your 11ty build. This helps us process all sorts of file types, including SCSS styles, React components, and more.
+2. Start up [a Vite server](https://vitejs.dev/guide/#index-html-and-project-root) pointed at your 11ty build. This helps us process all sorts of file types, including SCSS styles, React, Vue, or Svelte components, and more.
 
 [See our `slinkity` CLI docs](http://localhost:8080/docs/config/#the-slinkity-cli) for more details on how flags are processed.
 
@@ -57,7 +57,7 @@ But wait, we haven't tried any of Slinkity's features yet! Let's change that.
 
 ### Adding your first component shortcode
 
-Say you have a project directory with just 1 file: `index.html`. That file might look like this:
+Say you have a project directory with just 1 file: `index.njk`. That file might look like this:
 
 ```html
 <!DOCTYPE html>
@@ -76,49 +76,114 @@ Say you have a project directory with just 1 file: `index.html`. That file might
 
 If you run this using the `slinkity --serve --incremental` command, you'll just see the gloriously static text "Look ma, it's Slinkity!"
 
-But what if we want something... interactive? For instance, say we're tracking how many glasses of water we've had today (because [hydration is important](https://www.gatsbyjs.com/docs/conceptual/react-hydration/)!). If we know a little [ReactJS](https://reactjs.org/docs/getting-started.html), we can whip up a counter component under the `_includes/` directory like so:
+But what if we want something... interactive? For instance, say we're tracking how many glasses of water we've had today (because [hydration is important](https://www.gatsbyjs.com/docs/conceptual/react-hydration/)!). If we know a little JavaScript, we can whip up a counter using our favorite flavor of components.
+
+First, we'll install need one of our "renderers" to handle React, Vue, and/or Svelte. Don't worry, this is definitely a set-it-and-forget-it step 😁
+
+{% include 'prereqs.md' %}
+
+Now, we can write a component under the `_includes/` directory like so:
+
+{% slottedComponent "Tabs.svelte", hydrate="eager", id="prereqs", tabs=["React", "Vue", "Svelte"] %}
+{% renderTemplate "md" %}
+<section>
 
 ```jsx
 // _includes/GlassCounter.jsx
-import React, { useState } from 'react'
+import { useState } from 'react'
 
 function GlassCounter() {
-  // Declare a new state variable, which we'll call "count"
   const [count, setCount] = useState(0)
-
   return (
-    <div>
+    <>
       <p>You've had {count} glasses of water 💧</p>
       <button onClick={() => setCount(count + 1)}>Add one</button>
-    </div>
+    </>
   )
 }
 
 export default GlassCounter
 ```
 
-_**Note:** Make sure this file is under `_includes`. This is where our component shortcode will look for `GlassCounter` in a moment._
-
-Next, install `react` and `react-dom` as project dependencies. You might need to stop and restart your dev server if it's running:
-
-```bash
-npm i react react-dom
-```
-
-Finally, let's place this component on our `index.html` with a [component shortcode](/docs/component-shortcodes):
+Finally, let's place this component onto our page with a [component shortcode](/docs/component-shortcodes):
 
 ```html
 ...
 <body>
   <h1>Look ma, it's Slinkity!</h1>
-  {% raw %}{% react 'GlassCounter' %}{% endraw %}
+  {% component 'GlassCounter.jsx', hydrate='eager' %}
 </body>
 ```
+</section>
+<section hidden>
+
+```html
+<!--_includes/GlassCounter.vue-->
+<template>
+  <p>You've had {{ count }} glasses of water 💧</p>
+  <button @click="add()">Add one</button>
+</template>
+
+<script>
+import { ref } from "vue";
+
+export default {
+  setup() {
+    const count = ref(0);
+
+    function add() {
+      count.value += 1;
+    }
+
+    return { count, add };
+  },
+};
+</script>
+```
+
+Finally, let's place this component onto our page with a [component shortcode](/docs/component-shortcodes):
+
+```html
+...
+<body>
+  <h1>Look ma, it's Slinkity!</h1>
+  {% component 'GlassCounter.vue', hydrate='eager' %}
+</body>
+```
+</section>
+<section hidden>
+
+```html
+<!--_includes/GlassCounter.svelte-->
+<script>
+  let count = 0;
+
+  function add() {
+    count += 1;
+  }
+</script>
+
+<p>You've had {count} glasses of water 💧</p>
+<button on:click={add}>Add one</button>
+```
+
+Finally, let's place this component onto our page with a [component shortcode](/docs/component-shortcodes):
+
+```html
+...
+<body>
+  <h1>Look ma, it's Slinkity!</h1>
+  {% component 'GlassCounter.svelte', hydrate='eager' %}
+</body>
+```
+</section>
+{% endrenderTemplate %}
+{% endslottedComponent %}
 
 This will do a few things:
-1. Find `_includes/GlassCounter.jsx` (notice the file extension is optional)
+1. Find `_includes/GlassCounter.*`. Note that we'll always look inside the `_includes` directory to find your components.
 2. [Prerender](https://jamstack.org/glossary/pre-render/) your component at build time. This means you'll always see your component, even when disabling JS in your browser ([try it!](https://developer.chrome.com/docs/devtools/javascript/disable/)).
-3. ["Hydrate"](/docs/partial-hydration/) that prerendered component with JavaScript
+3. ["Hydrate"](/docs/partial-hydration/) that prerendered component with JavaScript. This is thanks to our `hydrate='eager'` flag.
 
 Now in your browser preview, clicking "Add one" should increase your counter 🎉
 

--- a/www/src/docs/quick-start.md
+++ b/www/src/docs/quick-start.md
@@ -78,7 +78,7 @@ If you run this using the `slinkity --serve --incremental` command, you'll just 
 
 But what if we want something... interactive? For instance, say we're tracking how many glasses of water we've had today (because [hydration is important](https://www.gatsbyjs.com/docs/conceptual/react-hydration/)!). If we know a little JavaScript, we can whip up a counter using our favorite flavor of components.
 
-First, we'll install need one of our "renderers" to handle React, Vue, and/or Svelte. Don't worry, this is definitely a set-it-and-forget-it step 😁
+First, we'll need one of our "renderers" to handle React, Vue, and/or Svelte. Don't worry, this is definitely a set-it-and-forget-it step 😁
 
 {% include 'prereqs.md' %}
 

--- a/www/src/docs/quick-start.md
+++ b/www/src/docs/quick-start.md
@@ -19,12 +19,10 @@ Want to bring Slinkity to your current 11ty project? No sweat! Slinkity is built
 First, install Slinkity + the latest 11ty into your project:
 
 ```bash
-npm i --save-dev slinkity @11ty/eleventy@beta
+npm i --save-dev slinkity @11ty/eleventy
 ```
 
 > Slinkity requires Node v14 and up. You can check your version by running `node -v` in your terminal before trying Slinkity.
-
-> Slinkity also relies on 11ty's [latest 1.0 beta build](https://www.npmjs.com/package/@11ty/eleventy/v/beta) to work properly. Yes, this could involve some gotchas with existing 11ty plugins! If anything unexpected happens, let us know on our [GitHub issues page](https://github.com/slinkity/slinkity/issues).
 
 ### Using the `slinkity` CLI
 

--- a/www/src/docs/quick-start.md
+++ b/www/src/docs/quick-start.md
@@ -5,8 +5,8 @@ title: Quick start
 {% include 'npm-init-slinkity-snippet.md' %}
 
 It includes:
-- a React component embedded into a static `.md` template → [more on component shortcodes here](/docs/component-shortcodes/)
-- a route built using a component framework as a templating language → [more on component pages here](/docs/component-pages-layouts/)
+- component(s) embedded into a static `.md` template → [more on component shortcodes here](/docs/component-shortcodes/)
+- route(s) built using a component framework as a templating language → [more on component pages here](/docs/component-pages-layouts/)
 - a `netlify.toml` configured to deploy in a flash → [more on deployment here](/docs/deployment/)
 - an eleventy config with a few recommended defaults → [more on config here](/docs/config/#recommended-config-options)
 


### PR DESCRIPTION
## What's changed?
- updated "features" table with renderers support 🎉
- update value proposition to use `component` shortcode, mention other component frameworks
- update `GlassCounter` walkthrough to include Vue and Svelte