### PR TITLE
Docs: new component shortcodes

### DIFF
--- a/www/src/_includes/currentTabStore.js
+++ b/www/src/_includes/currentTabStore.js
@@ -1,3 +1,3 @@
 import { writable } from 'svelte/store'
 
-export const currentTabIdx = writable(0)
+export const currentTabIdx = writable({ default: 0 })

--- a/www/src/docs/component-shortcodes.md
+++ b/www/src/docs/component-shortcodes.md
@@ -10,24 +10,41 @@ You can embed React, Vue, Svelte, and more into your existing templates. Let's l
 
 ## Basic usage
 
-Using the `react` [shortcode](https://www.11ty.dev/docs/shortcodes/), you can insert components into any static template that 11ty supports. First, ensure your component is:
-- **located in your includes directory** - defaults to `_includes`, but you can [override this from your eleventy config](https://www.11ty.dev/docs/config/#directory-for-includes)
-- **exports your component as a default export** (aka `export default ComponentName`) - named exports currently aren't supported
+Using the `component` [shortcode](https://www.11ty.dev/docs/shortcodes/), you can insert components into any static template that 11ty supports.
 
-Now, you can add a component shortcode to your template of choice:
+First, ensure your component is **located in your includes directory** This defaults to `_includes` for new 11ty projects, but you can [override this from your eleventy config](https://www.11ty.dev/docs/config/#directory-for-includes).
+
+For instance, say you've written a Vue component under `_includes/Component.vue`. You can insert this component into your templates like so:
+
+{% slottedComponent 'Tabs.svelte', hydrate='eager', id='shortcode-basics', store="templates", tabs=['njk', 'liquid', 'hbs'] %}
+{% renderTemplate 'md' %}
+<section>
 
 ```html
-<!--for nunjucks and liquid templates -->
-{% raw %}{% react 'path/to/Component' %}{% endraw %}
-
-<!--for handlebars templates --> 
-{% raw %}{{{ react 'path/to/Component' }}}{% endraw %}
+{% component 'Component.vue' %}
 ```
+</section>
+<section hidden>
+
+```html
+{% component 'Component.vue' %}
+```
+</section>
+<section hidden>
+
+```html
+{{{ component 'Component.vue' }}}
+```
+</section>
+{% endrenderTemplate %}
+{% endslottedComponent %}
+
+> These examples work from markdown (`.md`) and HTML (`.html`) files as well! You can use liquid syntax within either of these by default, though we recommend using Nunjucks instead. See [our recommend config options](/docs/config/#recommended-config-options) for more.
 
 This will do a few things:
-1. Find `_includes/path/to/Component.jsx` (notice the file extension is optional)
+1. Find `_includes/GlassCounter.*`. Note that we'll always look inside the `_includes` directory to find your components.
 2. [Prerender](https://jamstack.org/glossary/pre-render/) your component at build time. This means you'll always see your component, even when disabling JS in your browser ([try it!](https://developer.chrome.com/docs/devtools/javascript/disable/)).
-3. ["Hydrate"](/docs/partial-hydration/) that prerendered component with JavaScript
+3. ["Hydrate"](/docs/partial-hydration/) that prerendered component with JavaScript. This is thanks to our `hydrate='eager'` flag.
 
 ## Choose how and when to hydrate
 

--- a/www/src/docs/component-shortcodes.md
+++ b/www/src/docs/component-shortcodes.md
@@ -186,6 +186,119 @@ url=page.url, hydrate='eager', fileSlug=page.fileSlug %}
 
 > Is that a "hydrate" flag sandwiched between the other props? Yep! Do we care? Nope.
 
+## Pass children / unnamed slots to component
+
+We have a separate [paired shortcode](https://www.11ty.dev/docs/shortcodes/#paired-shortcodes) for passing child HTML: `slottedComponent`. 
+
+Say you have a simple component to wrap text with a dropdown toggle. That component could be written like so:
+
+{% slottedComponent "Tabs.svelte", hydrate="eager", id="slotted-component", tabs=["React", "Vue", "Svelte"] %}
+{% renderTemplate "md" %}
+<section>
+
+```jsx
+export default function Dropdown({ heading, children }) {
+  return (
+    <details>
+      <summary>{heading}</summary>
+      {children}
+    </details>
+  )
+}
+```
+</section>
+<section hidden>
+
+```html
+<template>
+  <details>
+    <summary>{{ heading }}</summary>
+    <slot />
+  </details>
+</template>
+
+<script>
+export default {
+  props: ["heading"],
+};
+</script>
+```
+</section>
+<section hidden>
+
+```html
+<script>
+  export let heading = "";
+</script>
+
+<details>
+  <summary>{heading}</summary>
+  <slot />
+</details>
+```
+</section>
+{% endrenderTemplate %}
+{% endslottedComponent %}
+
+You can use this component the same way as the `component` shortcode, now with children:
+
+{% slottedComponent 'Tabs.svelte', hydrate='eager', id='slotted-shortcode-usage', store='templates', tabs=['nunjucks', 'liquid'] %}
+{% renderTemplate 'md' %}
+<section>
+
+```html
+{% slottedComponent 'Dropdown.jsx|vue|svelte', heading='Full disclosure' %}
+<p>"details" and "summary" are kinda confusing element names</p>
+{% endslottedComponent %}
+```
+</section>
+<section hidden>
+
+```html
+{% slottedComponent 'Dropdown.jsx|vue|svelte' 'heading' 'Full disclosure' %}
+<p>"details" and "summary" are kinda confusing element names</p>
+{% endslottedComponent %}
+```
+</section>
+{% endrenderTemplate %}
+{% endslottedComponent %}
+
+### Important gotcha: templating in children
+
+You may be rushing to try slotted components in your markdown:
+
+```md{% raw %}
+{% slottedComponent 'FancyBackground.jsx|vue|svelte' %}
+### Why I love markdown
+
+- Bulleted lists are easy
+- Paragraph and code blocks are even easier
+
+{% endslottedComponent %}{% endraw %}
+```
+
+🚨 **Careful, this won't work as written!** Paired shortcode content is processed as plain HTML, so markdown syntax won't work as expected 😢
+
+But all is not lost. Since you _can_ still nest other shortcodes as paired shortcode content, you can use [11ty's handy `renderTemplate`](https://www.11ty.dev/docs/plugins/render/) like so:
+
+```md{% raw %}
+{% slottedComponent 'FancyBackground.jsx|vue|svelte' %}
+{% renderTemplate 'md' %}
+### Why I love markdown
+
+- Bulleted lists are easy
+- Paragraph and code blocks are even easier
+
+{% endrenderTemplate %}
+{% endslottedComponent %}{% endraw %}
+```
+
+> Be sure to set up `renderTemplate` in your 11ty config before trying this. [See their docs](https://www.11ty.dev/docs/plugins/render/) for more.
+
+This will process your markdown, then pass the result to your component.
+
+***
+
 So injecting components into templates is nice... but what if we want to build the entire route using a component framework?
 
 **[Learn about page-level components →](/docs/component-pages-layouts)**

--- a/www/src/docs/component-shortcodes.md
+++ b/www/src/docs/component-shortcodes.md
@@ -85,13 +85,25 @@ Let's say you have a date component written in your favorite framework (`_includ
 <section>
 
 ```html
-{% component 'Date.jsx|vue|svelte', data=page.date %}
+{% component 'Date.jsx|vue|svelte', date=page.date %}
+```
+
+Note that you can pass the `hydrate` flag alongside this prop as well. `hydrate` is considered just another prop, like any other! This should work fine for instance:
+
+```html
+{% component 'Date.jsx|vue|svelte', date=page.date, hydrate='eager' %}
 ```
 </section>
 <section hidden>
 
 ```html
 {% component 'Date.jsx|vue|svelte' 'date' page.date %}
+```
+
+Note that you can pass the `hydrate` flag alongside this prop as well. `hydrate` is considered just another prop, like any other! This should work fine for instance:
+
+```html
+{% component 'Date.jsx|vue|svelte' 'date' page.date 'hydrate' 'eager' %}
 ```
 </section>
 {% endrenderTemplate %}
@@ -138,7 +150,7 @@ export default {
 {% endrenderTemplate %}
 {% endslottedComponent %}
 
-### Passing multiple props
+### Pass multiple props
 
 You're free to pass as many key / value pairs as you want! The names and ordering of your keys shouldn't matter.
 

--- a/www/src/docs/component-shortcodes.md
+++ b/www/src/docs/component-shortcodes.md
@@ -12,7 +12,7 @@ You can embed React, Vue, Svelte, and more into your existing templates. Let's l
 
 Using the `component` [shortcode](https://www.11ty.dev/docs/shortcodes/), you can insert components into any static template that 11ty supports.
 
-First, ensure your component is **located in your includes directory** This defaults to `_includes` for new 11ty projects, but you can [override this from your eleventy config](https://www.11ty.dev/docs/config/#directory-for-includes).
+First, ensure your component is **located in your includes directory.** This defaults to `_includes` for new 11ty projects, but you can [override this from your eleventy config](https://www.11ty.dev/docs/config/#directory-for-includes).
 
 For instance, say you've written a Vue component under `_includes/Component.vue`. You can insert this component into your templates like so:
 
@@ -36,7 +36,7 @@ For instance, say you've written a Vue component under `_includes/Component.vue`
 > These examples work from markdown (`.md`) and HTML (`.html`) files as well! You can use liquid syntax within either of these by default, though we recommend using Nunjucks instead. See [our recommend config options](/docs/config/#recommended-config-options) for more.
 
 This will do a few things:
-1. Find `_includes/GlassCounter.*`. Note that we'll always look inside the `_includes` directory to find your components.
+1. Find `_includes/Component.vue`. Note that 1) we'll always look inside the `_includes` directory to find your components, and 2) the file extension is _required_ (`.jsx`, `.tsx`, `.svelte`, etc).
 2. [Prerender](https://jamstack.org/glossary/pre-render/) your component at build time. This means you'll always see your component, even when disabling JS in your browser ([try it!](https://developer.chrome.com/docs/devtools/javascript/disable/)).
 
 One feature we _won't_ provide automatically: hydrating on the client. In other words, your React `useState`, Vue `refs`, or Svelte stores won't work immediately. You'll need to opt-in to sending JavaScript to the browser, which brings us to our next section...
@@ -109,16 +109,20 @@ Note that you can pass the `hydrate` flag alongside this prop as well. `hydrate`
 {% endrenderTemplate %}
 {% endslottedComponent %}
 
-"date" is the key for our prop here, and `page.date` is the value passed by 11ty. You can access that `date` inside your component like so:
+You can access either of these props inside your component like so:
 
 {% slottedComponent "Tabs.svelte", hydrate="eager", id="component-props", tabs=["React", "Vue", "Svelte"] %}
 {% renderTemplate "md" %}
 <section>
 
 ```jsx
-export default function ViewDate({ date }) {
+export default function ViewDate({ date, hydrate }) {
   return (
-    <span>{date}</span>
+    <>
+      <span>{date}</span>
+      {/* ex. only show a button when the component is hydrated */}
+      {hydrate ? <button>Something interactive!</button> : null}
+    </>
   )
 }
 ```
@@ -128,11 +132,13 @@ export default function ViewDate({ date }) {
 ```html
 <template>
   <span>{{ date }}</span>
+  <!--ex. only show a button when the component is hydrated-->
+  <button v-if="hydrate">Something interactive!</button>
 </template>
 
 <script>
 export default {
-  props: ["date"],
+  props: ["date", "hydrate"],
 }
 </script>
 ```
@@ -142,9 +148,14 @@ export default {
 ```html
 <script>
   export let date = '';
+  export let hydrate = '';
 </script>
 
 <span>{date}</span>
+{#if hydrate}
+<!--ex. only show a button when the component is hydrated-->
+<button>Something interactive!</button>
+{/if}
 ```
 </section>
 {% endrenderTemplate %}

--- a/www/src/docs/component-shortcodes.md
+++ b/www/src/docs/component-shortcodes.md
@@ -16,7 +16,7 @@ First, ensure your component is **located in your includes directory** This defa
 
 For instance, say you've written a Vue component under `_includes/Component.vue`. You can insert this component into your templates like so:
 
-{% slottedComponent 'Tabs.svelte', hydrate='eager', id='shortcode-basics', store="templates", tabs=['njk', 'liquid', 'hbs'] %}
+{% slottedComponent 'Tabs.svelte', hydrate='eager', id='shortcode-basics', store='templates', tabs=['nunjucks', 'liquid'] %}
 {% renderTemplate 'md' %}
 <section>
 
@@ -30,12 +30,6 @@ For instance, say you've written a Vue component under `_includes/Component.vue`
 {% component 'Component.vue' %}
 ```
 </section>
-<section hidden>
-
-```html
-{{{ component 'Component.vue' }}}
-```
-</section>
 {% endrenderTemplate %}
 {% endslottedComponent %}
 
@@ -44,64 +38,105 @@ For instance, say you've written a Vue component under `_includes/Component.vue`
 This will do a few things:
 1. Find `_includes/GlassCounter.*`. Note that we'll always look inside the `_includes` directory to find your components.
 2. [Prerender](https://jamstack.org/glossary/pre-render/) your component at build time. This means you'll always see your component, even when disabling JS in your browser ([try it!](https://developer.chrome.com/docs/devtools/javascript/disable/)).
-3. ["Hydrate"](/docs/partial-hydration/) that prerendered component with JavaScript. This is thanks to our `hydrate='eager'` flag.
+
+One feature we _won't_ provide automatically: hydrating on the client. In other words, your React `useState`, Vue `refs`, or Svelte stores won't work immediately. You'll need to opt-in to sending JavaScript to the browser, which brings us to our next section...
 
 ## Choose how and when to hydrate
 
-Slinkity assumes you'll hydrate your component by default. In other words, we ship your component as a JavaScript bundle to ensure your stateful variables work on the client. But what if you _don't_ need to ship any interactivity?
+Slinkity requires a special `hydrate` prop to ship JavaScript alongside your components. This lets you use your favorite component framework for templating guilt-free, and opt-in to JS bundles when the need arises.
 
-To opt-out of shipping JS, you can render your component as "static" HTML and CSS like so:
+To hydrate that `Component.vue` from earlier, you can apply the `hydrate='eager'` flag:
+
+{% slottedComponent 'Tabs.svelte', hydrate='eager', id='shortcode-basics', store='templates', tabs=['nunjucks', 'liquid'] %}
+{% renderTemplate 'md' %}
+<section>
 
 ```html
-{% raw %}
-<!--for nunjucks templates -->
-{% react 'components/Date', render="static" %}
-
-<!--for liquid templates (note we can't use the "=" sign here!) -->
-{% react 'components/Date' 'render' 'static' %}
-
-<!--for handlebars templates --> 
-{{{ react 'components/Date', 'render', 'static' }}}
-{% endraw %}
+{% component 'Component.vue', hydrate='eager' %}
 ```
+
+> If you prefer the syntax available in nunjucks templates, we do too! We recommend configuring nunjucks as the default templating language for HTML and markdown files to access this syntax everywhere. [Head to our configuration docs](/docs/config/#11ty's-.eleventy.js) for more details.
+
+</section>
+<section hidden>
+
+```html
+{% component 'Component.vue' 'hydrate' 'eager' %}
+```
+
+> Liquid doesn't handle inline objects very well. So, we recommend passing each key-value pair as separate arguments as shown above. Each pair (ex. `'hydrate' 'eager'`) will be joined on our end (ex. `hydrate='eager'`).
+
+</section>
+{% endrenderTemplate %}
+{% endslottedComponent %}
 
 For a full list of options to fine-tune how and when JavaScript is loaded on the client...
 
 **[💧 Learn more about partial hydration →](/docs/partial-hydration)**
 
-## Passing props to shortcodes
+## Pass props to shortcodes
 
 You can also pass data to your components as key / value pairs.
 
-Let's say you have a date component that wants to use [11ty's supplied `date` object](https://www.11ty.dev/docs/data-eleventy-supplied/). You can pass this "date" prop like so:
+Let's say you have a date component written in your favorite framework (`_includes/Date.jsx|vue|svelte`) that wants to use [11ty's supplied `date` object](https://www.11ty.dev/docs/data-eleventy-supplied/). You can pass this "date" prop like so:
+
+{% slottedComponent 'Tabs.svelte', hydrate='eager', id='shortcode-basics', store='templates', tabs=['nunjucks', 'liquid'] %}
+{% renderTemplate 'md' %}
+<section>
 
 ```html
-<!--for nunjucks templates -->
-{% raw %}{% react 'components/Date', date=page.date %}{% endraw %}
-
-<!--for liquid templates (note we can't use the "=" sign here!) -->
-{% raw %}{% react 'components/Date' 'date' page.date %}{% endraw %}
-
-<!--for handlebars templates --> 
-{% raw %}{{{ react 'components/Date', 'date', page.date }}}{% endraw %}
+{% component 'Date.jsx|vue|svelte', data=page.date %}
 ```
+</section>
+<section hidden>
 
-> If you prefer the syntax available in nunjucks templates, we do too! We recommend configuring nunjucks as the default templating language for HTML and markdown files to access this syntax everywhere. [Head to our configuration docs](/docs/config/#11ty's-.eleventy.js) for more details.
+```html
+{% component 'Date.jsx|vue|svelte' 'date' page.date %}
+```
+</section>
+{% endrenderTemplate %}
+{% endslottedComponent %}
 
-"date" is the key for our prop here, and `page.date` is the value passed by 11ty. We can access our prop inside `components/Date.jsx` like so:
+"date" is the key for our prop here, and `page.date` is the value passed by 11ty. You can access that `date` inside your component like so:
+
+{% slottedComponent "Tabs.svelte", hydrate="eager", id="component-props", tabs=["React", "Vue", "Svelte"] %}
+{% renderTemplate "md" %}
+<section>
 
 ```jsx
-// _includes/Date.jsx
-import React from 'react'
-
-function ViewDate({ date }) {
+export default function ViewDate({ date }) {
   return (
     <span>{date}</span>
   )
 }
-
-export default ViewDate
 ```
+</section>
+<section hidden>
+
+```html
+<template>
+  <span>{{ date }}</span>
+</template>
+
+<script>
+export default {
+  props: ["date"],
+}
+</script>
+```
+</section>
+<section hidden>
+
+```html
+<script>
+  export let date = '';
+</script>
+
+<span>{date}</span>
+```
+</section>
+{% endrenderTemplate %}
+{% endslottedComponent %}
 
 ### Passing multiple props
 

--- a/www/src/docs/component-shortcodes.md
+++ b/www/src/docs/component-shortcodes.md
@@ -47,7 +47,7 @@ Slinkity requires a special `hydrate` prop to ship JavaScript alongside your com
 
 To hydrate that `Component.vue` from earlier, you can apply the `hydrate='eager'` flag:
 
-{% slottedComponent 'Tabs.svelte', hydrate='eager', id='shortcode-basics', store='templates', tabs=['nunjucks', 'liquid'] %}
+{% slottedComponent 'Tabs.svelte', hydrate='eager', id='shortcode-hydration', store='templates', tabs=['nunjucks', 'liquid'] %}
 {% renderTemplate 'md' %}
 <section>
 
@@ -80,7 +80,7 @@ You can also pass data to your components as key / value pairs.
 
 Let's say you have a date component written in your favorite framework (`_includes/Date.jsx|vue|svelte`) that wants to use [11ty's supplied `date` object](https://www.11ty.dev/docs/data-eleventy-supplied/). You can pass this "date" prop like so:
 
-{% slottedComponent 'Tabs.svelte', hydrate='eager', id='shortcode-basics', store='templates', tabs=['nunjucks', 'liquid'] %}
+{% slottedComponent 'Tabs.svelte', hydrate='eager', id='shortcode-date-prop', store='templates', tabs=['nunjucks', 'liquid'] %}
 {% renderTemplate 'md' %}
 <section>
 
@@ -165,7 +165,7 @@ export default {
 
 You're free to pass as many key / value pairs as you want. The names and ordering of your keys shouldn't matter, since they're all crunched into a single "props" object for your component.
 
-{% slottedComponent 'Tabs.svelte', hydrate='eager', id='shortcode-basics', store='templates', tabs=['nunjucks', 'liquid'] %}
+{% slottedComponent 'Tabs.svelte', hydrate='eager', id='shortcode-multiple-props', store='templates', tabs=['nunjucks', 'liquid'] %}
 {% renderTemplate 'md' %}
 <section>
 

--- a/www/src/docs/component-shortcodes.md
+++ b/www/src/docs/component-shortcodes.md
@@ -152,18 +152,29 @@ export default {
 
 ### Pass multiple props
 
-You're free to pass as many key / value pairs as you want! The names and ordering of your keys shouldn't matter.
+You're free to pass as many key / value pairs as you want. The names and ordering of your keys shouldn't matter, since they're all crunched into a single "props" object for your component.
+
+{% slottedComponent 'Tabs.svelte', hydrate='eager', id='shortcode-basics', store='templates', tabs=['nunjucks', 'liquid'] %}
+{% renderTemplate 'md' %}
+<section>
 
 ```html
-<!--for nunjucks templates-->
-{% raw %}{% react 'components/DisplayAllTheThings', date=page.date,
-url=page.url, fileSlug=page.fileSlug %}{% endraw %}
-
-<!--for liquid templates-->
-{% raw %}{% react 'components/DisplayAllTheThings' 'date' page.date
-'url' page.url 'fileSlug' page.fileSlug %}{% endraw %}
+{% component 'Apropcalypse.jsx|vue|svelte', date=page.date,
+url=page.url, hydrate='eager', fileSlug=page.fileSlug %}
 ```
+</section>
+<section hidden>
 
-Injecting components into templates is nice... but what if we want to build the entire route using a component framework?
+```html
+{% component 'Apropcalypse.jsx|vue|svelte' 'date' page.date
+'url' page.url 'hydrate' 'eager' 'fileSlug' page.fileSlug %}
+```
+</section>
+{% endrenderTemplate %}
+{% endslottedComponent %}
+
+> Is that a "hydrate" flag sandwiched between the other props? Yep! Do we care? Nope.
+
+So injecting components into templates is nice... but what if we want to build the entire route using a component framework?
 
 **[Learn about page-level components →](/docs/component-pages-layouts)**

--- a/www/styles/_base.scss
+++ b/www/styles/_base.scss
@@ -67,6 +67,10 @@ h2 {
   }
 }
 
+hr {
+  border: 1px solid var(--color-primary-7);
+}
+
 blockquote {
   --bg: var(--color-primary-7);
   --padding: clamp(1rem, 2vmax, 1.5em);


### PR DESCRIPTION
## What's changed?
- update `Tabs.svelte` to support multiple tab stores
- update styles for `hr` breaks
- rewrite component shortcode docs from the ground up with new features