### PR TITLE
Feat/improve production build efficiency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@babel/core": "^7.15.0",
     "@babel/preset-env": "^7.15.0",
+    "@types/jest": "^27.4.1",
     "babel-jest": "^27.1.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",

--- a/packages/slinkity/cli/toBuilder.js
+++ b/packages/slinkity/cli/toBuilder.js
@@ -1,9 +1,26 @@
+/**
+ * Builder to optimize calls to a given build function
+ * - Prevent duplicate calls based on a build "id"
+ * - Cache values for retrieval based on the "shouldUseCache" property
+ *
+ * @typedef {string | number} ID
+ * @typedef BuilderOptions
+ * @property {boolean} shouldUseCache
+ * @typedef {(id: ID, buildCallbackOptions: any, builderOptions: BuilderOptions) => Promise<void>} Build
+ * @param {(id: string | number, options: any)} buildCallback Function to call on build() request
+ * @return {{ build: Build }}
+ */
 module.exports.toBuilder = function (buildCallback) {
   const awaitingBuild = {}
   const buildCache = {}
 
-  function startBuild(id, options) {
-    buildCallback(id, options).then((buildResult) => {
+  /**
+   *
+   * @param {ID} id
+   * @param {any} buildCallbackOptions
+   */
+  function startBuild(id, buildCallbackOptions) {
+    buildCallback(id, buildCallbackOptions).then((buildResult) => {
       for (const cb of awaitingBuild[id]) {
         buildCache[id] = buildResult
         cb(buildResult)
@@ -13,16 +30,17 @@ module.exports.toBuilder = function (buildCallback) {
   }
 
   return {
-    build(id, options) {
+    /** @type {Build} */
+    build(id, buildCallbackOptions, { shouldUseCache } = { shouldUseCache: true }) {
       return new Promise(function (resolve) {
-        if (buildCache[id]) {
+        if (shouldUseCache && buildCache[id]) {
           resolve(buildCache[id])
           return
         }
 
         if (!awaitingBuild[id]) {
           awaitingBuild[id] = []
-          startBuild(id, options)
+          startBuild(id, buildCallbackOptions)
         }
         awaitingBuild[id].push((result) => {
           resolve(result)

--- a/packages/slinkity/cli/toBuilder.js
+++ b/packages/slinkity/cli/toBuilder.js
@@ -1,0 +1,33 @@
+module.exports.toBuilder = function (buildCallback) {
+  const awaitingBuild = {}
+  const buildCache = {}
+
+  function startBuild(id, options) {
+    buildCallback(id, options).then((buildResult) => {
+      for (const cb of awaitingBuild[id]) {
+        buildCache[id] = buildResult
+        cb(buildResult)
+      }
+      delete awaitingBuild[id]
+    })
+  }
+
+  return {
+    build(id, options) {
+      return new Promise(function (resolve) {
+        if (buildCache[id]) {
+          resolve(buildCache[id])
+          return
+        }
+
+        if (!awaitingBuild[id]) {
+          awaitingBuild[id] = []
+          startBuild(id, options)
+        }
+        awaitingBuild[id].push((result) => {
+          resolve(result)
+        })
+      })
+    },
+  }
+}

--- a/packages/slinkity/cli/toBuilder.js
+++ b/packages/slinkity/cli/toBuilder.js
@@ -37,7 +37,6 @@ module.exports.toBuilder = function (buildCallback) {
           resolve(buildCache[id])
           return
         }
-
         if (!awaitingBuild[id]) {
           awaitingBuild[id] = []
           startBuild(id, buildCallbackOptions)

--- a/packages/slinkity/cli/toBuilder.test.js
+++ b/packages/slinkity/cli/toBuilder.test.js
@@ -1,0 +1,47 @@
+const { toBuilder } = require('./toBuilder')
+
+describe('toBuilder', () => {
+  it('returns build result successfully', async () => {
+    const builder = toBuilder((id) => new Promise((resolve) => resolve(`built ${id}`)))
+    const buildResult = await builder.build('blog')
+    expect(buildResult).toEqual('built blog')
+  })
+  it('returns multiple built results successfully', async () => {
+    const builder = toBuilder((id) => new Promise((resolve) => resolve(`built ${id}`)))
+    const [blogResult, homeResult, contactResult] = await Promise.all([
+      builder.build('blog'),
+      builder.build('home'),
+      builder.build('contact'),
+    ])
+    expect(blogResult).toEqual('built blog')
+    expect(homeResult).toEqual('built home')
+    expect(contactResult).toEqual('built contact')
+  })
+  it('does not rerun build for same id', async () => {
+    const buildCallback = jest.fn()
+    buildCallback.mockImplementation(
+      (id) =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve(`built ${id}`), 50)
+        }),
+    )
+    const id = 'product-page'
+    const builder = toBuilder(buildCallback)
+    const results = await Promise.all([id, id, id, id, id, id].map((id) => builder.build(id)))
+    expect(buildCallback).toHaveBeenCalledTimes(1)
+    for (const result of results) {
+      expect(result).toEqual(`built ${id}`)
+    }
+  })
+  it('does not rerun build for cached values', async () => {
+    const buildCallback = jest.fn()
+    buildCallback.mockImplementation((id) => new Promise((resolve) => resolve(`built ${id}`), 10))
+    const id = 'cached-page'
+    const builder = toBuilder(buildCallback)
+    await builder.build(id)
+    expect(buildCallback).toHaveBeenCalledTimes(1)
+    buildCallback.mockClear()
+    await builder.build(id)
+    expect(buildCallback).toHaveBeenCalledTimes(0)
+  })
+})

--- a/packages/slinkity/cli/toBuilder.test.js
+++ b/packages/slinkity/cli/toBuilder.test.js
@@ -17,7 +17,7 @@ describe('toBuilder', () => {
     expect(homeResult).toEqual('built home')
     expect(contactResult).toEqual('built contact')
   })
-  it('does not rerun build for same id', async () => {
+  it('does not rerun build for same id while async build is resolving', async () => {
     const buildCallback = jest.fn()
     buildCallback.mockImplementation(
       (id) =>
@@ -43,5 +43,16 @@ describe('toBuilder', () => {
     buildCallback.mockClear()
     await builder.build(id)
     expect(buildCallback).toHaveBeenCalledTimes(0)
+  })
+  it('does rerun build when cache is disabled', async () => {
+    const buildCallback = jest.fn()
+    buildCallback.mockImplementation((id) => new Promise((resolve) => resolve(`built ${id}`), 10))
+    const id = 'cached-page'
+    const builder = toBuilder(buildCallback)
+    await builder.build(id)
+    expect(buildCallback).toHaveBeenCalledTimes(1)
+    buildCallback.mockClear()
+    await builder.build(id, null, { shouldUseCache: false })
+    expect(buildCallback).toHaveBeenCalledTimes(1)
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ importers:
     specifiers:
       '@babel/core': ^7.15.0
       '@babel/preset-env': ^7.15.0
+      '@types/jest': ^27.4.1
       babel-jest: ^27.1.0
       eslint: ^7.32.0
       eslint-config-prettier: ^8.3.0
@@ -25,6 +26,7 @@ importers:
     devDependencies:
       '@babel/core': 7.16.12
       '@babel/preset-env': 7.16.11_@babel+core@7.16.12
+      '@types/jest': 27.4.1
       babel-jest: 27.4.6_@babel+core@7.16.12
       eslint: 7.32.0
       eslint-config-prettier: 8.3.0_eslint@7.32.0
@@ -1886,6 +1888,13 @@ packages:
     resolution: {integrity: sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==}
     dependencies:
       '@types/istanbul-lib-report': 3.0.0
+    dev: true
+
+  /@types/jest/27.4.1:
+    resolution: {integrity: sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==}
+    dependencies:
+      jest-matcher-utils: 27.4.6
+      pretty-format: 27.4.6
     dev: true
 
   /@types/minimatch/3.0.5:


### PR DESCRIPTION
Resolves #203 

## What's changed?
- Introduce a new `toBuilder` helper. This accepts a generic build callback and manages the caching / scheduling portion.
- Attach `toBuilder` to our existing SSR flow.
- Add unit tests.
- Misc: add `@types/jest`.