### PR TITLE
Expose slinkity's intermediateDir to a `process.env` variable

### DIFF
--- a/packages/slinkity/cli/index.js
+++ b/packages/slinkity/cli/index.js
@@ -101,6 +101,7 @@ const userConfigDir = toEleventyConfigDir({
   const userSlinkityConfig = await readUserSlinkityConfig()
   await emptyDir(outputDir)
   if (options.serve) {
+    process.env.ELEVENTY_BUILD_OUTPUT_DIR = userConfigDir.output
     await startEleventy({
       dir: userConfigDir,
       userSlinkityConfig,

--- a/packages/slinkity/cli/index.js
+++ b/packages/slinkity/cli/index.js
@@ -108,6 +108,7 @@ const userConfigDir = toEleventyConfigDir({
     })
   } else {
     const intermediateDir = relative('.', await mkdtemp('.11ty-build-'))
+    process.env.ELEVENTY_BUILD_OUTPUT_DIR = intermediateDir
 
     // Eleventy builds to an internal temp directory
     // For Vite to pull from in a 2 step build process

--- a/www/src/docs/asset-management.md
+++ b/www/src/docs/asset-management.md
@@ -184,6 +184,8 @@ Note that the `public` directory should be **at the root level of your passthrou
 If you’re using the [Eleventy Image](https://www.11ty.dev/docs/plugins/image/) plugin to generate multiple formats, sizes or locally cached remote images you’ll need to configure it in a slinkity specific way. Slinkity generates an intermediate build folder (eg. `.11ty-build-DcNVBN`) and exposes this folder in `process.env.ELEVENTY_BUILD_OUTPUT_DIR` which you can use to generate the images to, as per:
 
 ```js
+const path = require('path')
+
 await Image(src, {
   widths: [300, 600],
   formats: ["avif", "jpeg"],

--- a/www/src/docs/asset-management.md
+++ b/www/src/docs/asset-management.md
@@ -191,4 +191,4 @@ await Image(src, {
 });
 ```
 
-For further Eleventy Image configuration you can check out their [excellent docs](https://www.11ty.dev/docs/plugins/image/).
+For further Eleventy Image configuration, you can check out their [excellent docs](https://www.11ty.dev/docs/plugins/image/).

--- a/www/src/docs/asset-management.md
+++ b/www/src/docs/asset-management.md
@@ -191,4 +191,4 @@ await Image(src, {
 });
 ```
 
-For further Eleventy Image configuration you can check out their [excellent docs](https://www.11ty.dev/docs/plugins/image/)
+For further Eleventy Image configuration you can check out their [excellent docs](https://www.11ty.dev/docs/plugins/image/).

--- a/www/src/docs/asset-management.md
+++ b/www/src/docs/asset-management.md
@@ -179,3 +179,16 @@ module.exports = function(eleventyConfig) {
 ```
 
 Note that the `public` directory should be **at the root level of your passthrough copy**.
+
+## Integrating Eleventy Image
+If you’re using the [Eleventy Image](https://www.11ty.dev/docs/plugins/image/) plugin to generate multiple formats, sizes or locally cached remote images you’ll need to configure it in a slinkity specific way. Slinkity generates an intermediate build folder (eg. `.11ty-build-DcNVBN`) and exposes this folder in `process.env.ELEVENTY_BUILD_OUTPUT_DIR` which you can use to generate the images to, as per:
+
+```js
+await Image(src, {
+  widths: [300, 600],
+  formats: ["avif", "jpeg"],
+  outputDir: path.join(process.env.ELEVENTY_BUILD_OUTPUT_DIR, 'img')
+});
+```
+
+For further Eleventy Image configuration you can check out their [excellent docs](https://www.11ty.dev/docs/plugins/image/)

--- a/www/src/docs/asset-management.md
+++ b/www/src/docs/asset-management.md
@@ -181,7 +181,7 @@ module.exports = function(eleventyConfig) {
 Note that the `public` directory should be **at the root level of your passthrough copy**.
 
 ## Integrating Eleventy Image
-If you’re using the [Eleventy Image](https://www.11ty.dev/docs/plugins/image/) plugin to generate multiple formats, sizes or locally cached remote images you’ll need to configure it in a slinkity specific way. Slinkity generates an intermediate build folder (eg. `.11ty-build-DcNVBN`) and exposes this folder in `process.env.ELEVENTY_BUILD_OUTPUT_DIR` which you can use to generate the images to, as per:
+If you’re using the [Eleventy Image](https://www.11ty.dev/docs/plugins/image/) plugin to generate multiple formats, sizes or locally cached remote images, you’ll need to configure the build output in a Slinkity-specific way. Slinkity generates an intermediate build folder (eg. `.11ty-build-DcNVBN`) and exposes the path on an environment variable: `process.env.ELEVENTY_BUILD_OUTPUT_DIR`. You can use this as a destination for 11ty image and anything else that outputs to the build directory. For example:
 
 ```js
 const path = require('path')


### PR DESCRIPTION
This PR adds the exposure of `intermediateDir`(eg. `.11ty-build-DcNVBN`) to `process.env.ELEVENTY_BUILD_OUTPUT_DIR`. 
This is mainly used for Eleventy Image integration and makes https://github.com/slinkity/slinkity/issues/74#issuecomment-1003030190 possible.