### PR TITLE
Rename `slinkity-react-mount-point` to `slinkity-mount-point`

### DIFF
--- a/packages/slinkity/client/toMountPointById.js
+++ b/packages/slinkity/client/toMountPointById.js
@@ -1,3 +1,3 @@
 export function toMountPointById(id) {
-  return document.querySelector(`slinkity-react-mount-point[data-s-id="${id}"]`)
+  return document.querySelector(`slinkity-mount-point[data-s-id="${id}"]`)
 }

--- a/packages/slinkity/eleventyConfig/__snapshots__/applyViteHtmlTransform.test.js.snap
+++ b/packages/slinkity/eleventyConfig/__snapshots__/applyViteHtmlTransform.test.js.snap
@@ -7,8 +7,8 @@ exports[`applyViteHtmlTransform handleSSRComments should inject children as stri
   <title>It's hydration time</title>
 </head>
 <body>
-<slinkity-react-mount-point data-s-id=\\"0\\"><react>Content</react>
-  <p>rendered by react</p></slinkity-react-mount-point>
+<slinkity-mount-point data-s-id=\\"0\\"><react>Content</react>
+  <p>rendered by react</p></slinkity-mount-point>
 <script type=\\"module\\">
     import Component0 from \\"nice.jsx\\";
     import renderer0 from \\"@slinkity/example/client\\";
@@ -23,8 +23,8 @@ exports[`applyViteHtmlTransform handleSSRComments should inject children as stri
 <h2>Boy do I love react!</h2>\`,
     });
   </script>
-<slinkity-react-mount-point data-s-id=\\"1\\"><svelte>Content</svelte>
-  <p>rendered by svelte</p></slinkity-react-mount-point>
+<slinkity-mount-point data-s-id=\\"1\\"><svelte>Content</svelte>
+  <p>rendered by svelte</p></slinkity-mount-point>
 <script type=\\"module\\">
     import Component1 from \\"cool.svelte\\";
     import renderer1 from \\"@slinkity/svelte/client\\";
@@ -39,8 +39,8 @@ exports[`applyViteHtmlTransform handleSSRComments should inject children as stri
 <h2>Boy do I love svelte!</h2>\`,
     });
   </script>
-<slinkity-react-mount-point data-s-id=\\"2\\"><vue>Content</vue>
-  <p>rendered by vue</p></slinkity-react-mount-point>
+<slinkity-mount-point data-s-id=\\"2\\"><vue>Content</vue>
+  <p>rendered by vue</p></slinkity-mount-point>
 <script type=\\"module\\">
     import Component2 from \\"neat.vue\\";
     import renderer2 from \\"@slinkity/vue/client\\";
@@ -66,8 +66,8 @@ exports[`applyViteHtmlTransform handleSSRComments should inject props as object 
   <title>It's hydration time</title>
 </head>
 <body>
-<slinkity-react-mount-point data-s-id=\\"0\\"><react>Content</react>
-  <p>rendered by react</p></slinkity-react-mount-point>
+<slinkity-mount-point data-s-id=\\"0\\"><react>Content</react>
+  <p>rendered by react</p></slinkity-mount-point>
 <script type=\\"module\\">
     import Component0 from \\"nice.jsx\\";
     import renderer0 from \\"@slinkity/example/client\\";
@@ -82,8 +82,8 @@ exports[`applyViteHtmlTransform handleSSRComments should inject props as object 
 \`,
     });
   </script>
-<slinkity-react-mount-point data-s-id=\\"1\\"><svelte>Content</svelte>
-  <p>rendered by svelte</p></slinkity-react-mount-point>
+<slinkity-mount-point data-s-id=\\"1\\"><svelte>Content</svelte>
+  <p>rendered by svelte</p></slinkity-mount-point>
 <script type=\\"module\\">
     import Component1 from \\"cool.svelte\\";
     import renderer1 from \\"@slinkity/svelte/client\\";
@@ -98,8 +98,8 @@ exports[`applyViteHtmlTransform handleSSRComments should inject props as object 
 \`,
     });
   </script>
-<slinkity-react-mount-point data-s-id=\\"2\\"><vue>Content</vue>
-  <p>rendered by vue</p></slinkity-react-mount-point>
+<slinkity-mount-point data-s-id=\\"2\\"><vue>Content</vue>
+  <p>rendered by vue</p></slinkity-mount-point>
 <script type=\\"module\\">
     import Component2 from \\"neat.vue\\";
     import renderer2 from \\"@slinkity/vue/client\\";
@@ -141,8 +141,8 @@ exports[`applyViteHtmlTransform handleSSRComments should replace SSR comments wi
   <title>It's hydration time</title>
 </head>
 <body>
-<slinkity-react-mount-point data-s-id=\\"0\\"><react>Content</react>
-  <p>rendered by react</p></slinkity-react-mount-point>
+<slinkity-mount-point data-s-id=\\"0\\"><react>Content</react>
+  <p>rendered by react</p></slinkity-mount-point>
 <script type=\\"module\\">
     import Component0 from \\"nice.jsx\\";
     import renderer0 from \\"@slinkity/example/client\\";
@@ -157,8 +157,8 @@ exports[`applyViteHtmlTransform handleSSRComments should replace SSR comments wi
 \`,
     });
   </script>
-<slinkity-react-mount-point data-s-id=\\"1\\"><svelte>Content</svelte>
-  <p>rendered by svelte</p></slinkity-react-mount-point>
+<slinkity-mount-point data-s-id=\\"1\\"><svelte>Content</svelte>
+  <p>rendered by svelte</p></slinkity-mount-point>
 <script type=\\"module\\">
     import Component1 from \\"cool.svelte\\";
     import renderer1 from \\"@slinkity/svelte/client\\";
@@ -173,8 +173,8 @@ exports[`applyViteHtmlTransform handleSSRComments should replace SSR comments wi
 \`,
     });
   </script>
-<slinkity-react-mount-point data-s-id=\\"2\\"><vue>Content</vue>
-  <p>rendered by vue</p></slinkity-react-mount-point>
+<slinkity-mount-point data-s-id=\\"2\\"><vue>Content</vue>
+  <p>rendered by vue</p></slinkity-mount-point>
 <script type=\\"module\\">
     import Component2 from \\"neat.vue\\";
     import renderer2 from \\"@slinkity/vue/client\\";

--- a/packages/slinkity/eleventyConfig/applyViteHtmlTransform.js
+++ b/packages/slinkity/eleventyConfig/applyViteHtmlTransform.js
@@ -2,7 +2,7 @@ const { normalizePath } = require('vite')
 const { relative } = require('path')
 const {
   SLINKITY_ATTRS,
-  SLINKITY_REACT_MOUNT_POINT,
+  SLINKITY_MOUNT_POINT,
   SLINKITY_HEAD_STYLES,
   toSSRComment,
 } = require('../utils/consts')
@@ -85,7 +85,7 @@ async function handleSSRComments({
         children,
       })
       const attrs = toHtmlAttrString({ [SLINKITY_ATTRS.id]: id })
-      return `<${SLINKITY_REACT_MOUNT_POINT} ${attrs}>${serverRenderedComponents[id]}</${SLINKITY_REACT_MOUNT_POINT}>\n${loaderScript}`
+      return `<${SLINKITY_MOUNT_POINT} ${attrs}>${serverRenderedComponents[id]}</${SLINKITY_MOUNT_POINT}>\n${loaderScript}`
     })
 
   if (html.match(ssrRegex)) {

--- a/packages/slinkity/utils/consts.js
+++ b/packages/slinkity/utils/consts.js
@@ -6,7 +6,7 @@ const { v4: uuidv4 } = require('uuid')
  *
  * @typedef SlinkityAttrs
  * @property {string} id - ID to identify mount points in the DOM for hydration
- 
+
  * @type {SlinkityAttrs}
  */
 const SLINKITY_ATTRS = {
@@ -34,7 +34,7 @@ const PACKAGES = {
 /**
  * Name for the web component used to mount React
  */
-const SLINKITY_REACT_MOUNT_POINT = 'slinkity-react-mount-point'
+const SLINKITY_MOUNT_POINT = 'slinkity-mount-point'
 
 /**
  * File name for user slinkity config files
@@ -58,7 +58,7 @@ const SLINKITY_HEAD_STYLES = toSSRComment('styles')
 module.exports = {
   SLINKITY_ATTRS,
   SLINKITY_CONFIG_FILE_NAME,
-  SLINKITY_REACT_MOUNT_POINT,
+  SLINKITY_MOUNT_POINT,
   IMPORT_ALIASES,
   SLINKITY_HEAD_STYLES,
   PACKAGES,


### PR DESCRIPTION
Slinkity renders a mount point around rendered components. I'm using Svelte and the component is rendered in a `react-mount-point`. This works, but is not that great. This PR renames `slinkity-react-mount-point` to `slinkity-mount-point`.