### PR TITLE
Feat: create slinkity updates

### DIFF
--- a/.changeset/strong-geese-explode.md
+++ b/.changeset/strong-geese-explode.md
@@ -1,0 +1,5 @@
+---
+"create-slinkity": minor
+---
+
+Update for new Slinkity configuration in v0.8. This removes all references to the slinkity CLI, and writes the new 11ty plugin into your generated 11ty config

--- a/packages/create-slinkity/template/.eleventy.js
+++ b/packages/create-slinkity/template/.eleventy.js
@@ -1,4 +1,10 @@
+const slinkity = require('slinkity')// insert renderer imports here
+
 module.exports = function (eleventyConfig) {
+  eleventyConfig.addPlugin(slinkity.plugin, slinkity.defineConfig({
+    renderers: [/* apply component renderers here */],
+  }))
+
   /**
    * Why copy the /public directory?
    * 

--- a/packages/create-slinkity/template/package.json
+++ b/packages/create-slinkity/template/package.json
@@ -11,6 +11,6 @@
   "dependencies": {},
   "devDependencies": {
     "@11ty/eleventy": "^1.0.0",
-    "slinkity": "^0.7.0"
+    "slinkity": "^0.8.0"
   }
 }

--- a/packages/create-slinkity/template/package.json
+++ b/packages/create-slinkity/template/package.json
@@ -4,9 +4,9 @@
   "description": "A splendid starter for my Slinkity site!",
   "main": ".eleventy.js",
   "scripts": {
-    "dev": "slinkity --serve --incremental",
-    "start": "slinkity --serve --incremental",
-    "build": "slinkity"
+    "dev": "eleventy --serve --incremental",
+    "start": "eleventy --serve --incremental",
+    "build": "eleventy"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/create-slinkity/template/src/deployment.md
+++ b/packages/create-slinkity/template/src/deployment.md
@@ -3,14 +3,14 @@ title: Deployment
 layout: layout
 ---
 
-Slinkity projects can be hosted with the same `build` command and `publish` directory on any of the common Jamstack hosting providers such as [Netlify](https://ajcwebdev-slinkity.netlify.app/), [Vercel](https://ajcwebdev-slinkity.vercel.app/), or [Cloudflare Pages](https://ajcwebdev-slinkity.pages.dev/). All three of these options allow you to create a custom domain name as well.
+11ty + Slinkity projects can be hosted with the same `build` command and `publish` directory on any of the common Jamstack hosting providers such as [Netlify](https://ajcwebdev-slinkity.netlify.app/), [Vercel](https://ajcwebdev-slinkity.vercel.app/), or [Cloudflare Pages](https://ajcwebdev-slinkity.pages.dev/). All three of these options allow you to create a custom domain name as well.
 
 ### Deploy to Netlify
 
-The `netlify.toml` file includes `npx slinkity` for the build command and `_site` for the publish directory.
+The `netlify.toml` file includes `npx eleventy` for the build command and `_site` for the publish directory.
 
 ```toml
 [build]
-  command = "npx slinkity"
+  command = "npx eleventy"
   publish = "_site"
 ```

--- a/www/src/docs/deployment.md
+++ b/www/src/docs/deployment.md
@@ -2,7 +2,7 @@
 title: Deployment
 ---
 
-Slinkity projects can be hosted on any of the common Jamstack hosting providers such as [Netlify](https://netlify.com/) and [Vercel](https://vercel.com/). If you're already hosting your site using 11ty, deploying with Slinkity should be quite similar!
+Slinkity projects can be hosted on any of the common Jamstack hosting providers such as [Netlify](https://netlify.com/) and [Vercel](https://vercel.com/). If you're already hosting your site using 11ty, **there's nothing to update!** Still, we'll include deployment instructions here to be thorough.
 
 ## `netlify.toml`
 
@@ -12,10 +12,10 @@ Create a `netlify.toml` file.
 touch netlify.toml
 ```
 
-Include `npx slinkity` for the build command and `_site` for the publish directory.
+Include `npx eleventy` for the build command and `_site` for the publish directory.
 
 ```toml
 [build]
-  command = "npx slinkity"
+  command = "npx eleventy"
   publish = "_site"
 ```


### PR DESCRIPTION
## What's changed?
- Update `create-slinkity` command to use new Slinkity 0.8 dependency
- Remove `slinkity.config.js` generation, and write the plugin declaration to the 11ty config
- Update deployment instructions to use plain `eleventy` CLI