### PR TITLE
Feat: serverless Vite support!

### DIFF
--- a/packages/slinkity/eleventyConfig/addComponentPages.js
+++ b/packages/slinkity/eleventyConfig/addComponentPages.js
@@ -39,9 +39,9 @@ module.exports = function addComponentPages({
         return await getData(absInputPath)
       },
       compileOptions: {
-        permalink() {
+        permalink(permalink) {
           const __functions = this
-          return function render({ permalink, ...data }) {
+          return function render(data) {
             if (typeof permalink === 'function') {
               return permalink({ ...data, __functions })
             } else {
@@ -98,6 +98,7 @@ module.exports = function addComponentPages({
             isSSR,
             loader: loader.mode ? loader.mode : loader,
             pageOutputPath: data.page.outputPath,
+            pageUrl: data.page.url,
             rendererName: renderer.name,
           })
 

--- a/packages/slinkity/eleventyConfig/addComponentShortcodes.js
+++ b/packages/slinkity/eleventyConfig/addComponentShortcodes.js
@@ -161,5 +161,6 @@ See our docs for more: https://slinkity.dev/docs/component-shortcodes`)
     loader: props.renderWithoutSSR ?? props.hydrate ?? 'none',
     children,
     pageOutputPath: page.outputPath,
+    pageUrl: page.url,
   }
 }

--- a/packages/slinkity/eleventyConfig/applyViteHtmlTransform.js
+++ b/packages/slinkity/eleventyConfig/applyViteHtmlTransform.js
@@ -26,7 +26,7 @@ function isSupportedOutputPath(outputPath) {
  * Extracted from applyViteHtmlTransform for unit testing!
  * @typedef HandleSSRCommentsParams
  * @property {string} content - the original HTML content to transform
- * @property {import('./componentAttrStore').ComponentLookupId} componentLookupId - identifier to lookup components from componentAttrStore
+ * @property {string} componentLookupId - identifier to lookup components from componentAttrStore
  * @property {import('./componentAttrStore').ComponentAttrStore} componentAttrStore
  * @property {import('../@types').ViteSSR} viteSSR
  * @property {import('../@types').Renderer[]} renderers
@@ -140,7 +140,7 @@ async function handleSSRComments({
 /**
  * @typedef ApplyViteHtmlTransformParams
  * @property {string} content - the original HTML content to transform
- * @property {import('./componentAttrStore').ComponentLookupId} componentLookupId - identifier to lookup components from componentAttrStore
+ * @property {string} componentLookupId - identifier to lookup components from componentAttrStore
  * @property {import('./componentAttrStore').ComponentAttrStore} componentAttrStore
  * @property {import('../@types').Renderer[]} renderers
  * @property {import('../@types').ViteSSR} viteSSR
@@ -162,8 +162,8 @@ async function applyViteHtmlTransform({
     renderers,
   })
   const server = viteSSR.getServer()
-  if (server && componentLookupId.type === 'url') {
-    return server.transformIndexHtml(componentLookupId.id, html)
+  if (server) {
+    return server.transformIndexHtml(componentLookupId, html)
   } else {
     return html
   }

--- a/packages/slinkity/eleventyConfig/componentAttrStore.js
+++ b/packages/slinkity/eleventyConfig/componentAttrStore.js
@@ -28,8 +28,9 @@
  * @returns {ComponentAttrStore}
  */
 function toComponentAttrStore({ lookupType }) {
-  /** @type {Record<string, ComponentAttrs[]>} */
-  let componentAttrStore = {}
+  /** @type {Record<string, Record<string, ComponentAttrs[]>>} */
+  let componentAttrStoreByEnv = {}
+  let env = ''
 
   /**
    * Add a new item to the store, and receive an index used for later get() calls
@@ -40,11 +41,14 @@ function toComponentAttrStore({ lookupType }) {
     const { pageOutputPath, pageUrl } = componentAttrs
     const pageId = lookupType === 'outputPath' ? pageOutputPath : pageUrl
 
-    if (!componentAttrStore[pageId]) {
-      componentAttrStore[pageId] = []
+    if (!componentAttrStoreByEnv[env]) {
+      componentAttrStoreByEnv[env] = {}
     }
-    const id = componentAttrStore[pageId].length
-    componentAttrStore[pageId].push({ ...componentAttrs, id })
+    if (!componentAttrStoreByEnv[env][pageId]) {
+      componentAttrStoreByEnv[env][pageId] = []
+    }
+    const id = componentAttrStoreByEnv[env][pageId].length
+    componentAttrStoreByEnv[env][pageId].push({ ...componentAttrs, id })
 
     return id
   }
@@ -55,7 +59,7 @@ function toComponentAttrStore({ lookupType }) {
    * @returns {ComponentAttrs[]} list of attributes for all components on the page
    */
   function getAllByPage(id) {
-    return componentAttrStore[id] ?? []
+    return componentAttrStoreByEnv[env][id] ?? []
   }
 
   /**
@@ -63,13 +67,16 @@ function toComponentAttrStore({ lookupType }) {
    * Should be used to reset between builds
    */
   function clear() {
-    componentAttrStore = {}
+    componentAttrStoreByEnv[env] = {}
   }
 
   return {
     push,
     getAllByPage,
     clear,
+    setEnv(newEnv) {
+      env = newEnv
+    },
   }
 }
 

--- a/packages/slinkity/eleventyConfig/componentAttrStore.js
+++ b/packages/slinkity/eleventyConfig/componentAttrStore.js
@@ -1,14 +1,8 @@
-const { isSupportedOutputPath } = require('./applyViteHtmlTransform')
-
 /**
  * The componentAttrStore is the bridge between page + shortcode components
  * and our HTML transform that *renders* those components.
  * - component mount points are ID'd by their index in the DOM for a given page (first, second, etc)
  * - by passing in an id, you'll receive all values necessary to render that mount point (see ComponentAttrs type def)
- *
- * @typedef ComponentLookupId
- * @property {'url' | 'outputPath'} type
- * @property {string} id
  *
  * @typedef {string} ID
  * @typedef ComponentAttrs
@@ -22,19 +16,20 @@ const { isSupportedOutputPath } = require('./applyViteHtmlTransform')
  * @property {string} pageUrl - the output URL where this component is served, based on 11ty's page.url property (ex. /about/)
  * @property {ID} id - a unique identifier for later retrieval from the store
  *
+ * @typedef ComponentAttrStoreParams
+ * @property {'url' | 'outputPath'} lookupType
+ *
  * @typedef {{
- *  getAllByPage: (componentLookupId: ComponentLookupId) => ComponentAttrs[];
+ *  getAllByPage: (id: string) => ComponentAttrs[];
  *  push: (componentAttrs: ComponentAttrs) => number;
  *  clear: () => void;
  * }} ComponentAttrStore
+ * @param {ComponentAttrStoreParams} params
  * @returns {ComponentAttrStore}
  */
-function toComponentAttrStore() {
+function toComponentAttrStore({ lookupType }) {
   /** @type {Record<string, ComponentAttrs[]>} */
-  let componentAttrStoreByOutputPath = {}
-
-  /** @type {Record<string, ComponentAttrs[]>} */
-  let componentAttrStoreByUrl = {}
+  let componentAttrStore = {}
 
   /**
    * Add a new item to the store, and receive an index used for later get() calls
@@ -43,41 +38,24 @@ function toComponentAttrStore() {
    */
   function push(componentAttrs) {
     const { pageOutputPath, pageUrl } = componentAttrs
-    let id = 0
-    if (!isSupportedOutputPath(pageOutputPath) && !pageUrl) {
-      throw Error(
-        '[Slinkity] You are using a component on an unsupported page. Ensure you are only using components on pages with a .html output extension.',
-      )
+    const pageId = lookupType === 'outputPath' ? pageOutputPath : pageUrl
+
+    if (!componentAttrStore[pageId]) {
+      componentAttrStore[pageId] = []
     }
-    if (isSupportedOutputPath(pageOutputPath)) {
-      if (!componentAttrStoreByOutputPath[pageOutputPath]) {
-        componentAttrStoreByOutputPath[pageOutputPath] = []
-      }
-      id = componentAttrStoreByOutputPath[pageOutputPath].length
-      componentAttrStoreByOutputPath[pageOutputPath].push({ ...componentAttrs, id })
-    }
-    if (pageUrl) {
-      if (!componentAttrStoreByUrl[pageUrl]) {
-        componentAttrStoreByUrl[pageUrl] = []
-      }
-      id = componentAttrStoreByUrl[pageUrl].length
-      componentAttrStoreByUrl[pageUrl].push({ ...componentAttrs, id })
-    }
+    const id = componentAttrStore[pageId].length
+    componentAttrStore[pageId].push({ ...componentAttrs, id })
+
     return id
   }
 
   /**
    * Get attributes for all components on a given page
-   * @param {ComponentLookupId} componentLookupId - either the url or outputPath where this page is served
+   * @param {string} id - either the url or outputPath where this page is served, depending on the lookupType
    * @returns {ComponentAttrs[]} list of attributes for all components on the page
    */
-  function getAllByPage(componentLookupId) {
-    if (componentLookupId.type === 'outputPath') {
-      return componentAttrStoreByOutputPath[componentLookupId.id] ?? []
-    } else if (componentLookupId.type === 'url') {
-      return componentAttrStoreByUrl[componentLookupId.id] ?? []
-    }
-    return []
+  function getAllByPage(id) {
+    return componentAttrStore[id] ?? []
   }
 
   /**
@@ -85,8 +63,7 @@ function toComponentAttrStore() {
    * Should be used to reset between builds
    */
   function clear() {
-    componentAttrStoreByOutputPath = {}
-    componentAttrStoreByUrl = {}
+    componentAttrStore = {}
   }
 
   return {

--- a/packages/slinkity/eleventyConfig/componentAttrStore.js
+++ b/packages/slinkity/eleventyConfig/componentAttrStore.js
@@ -1,8 +1,14 @@
+const { isSupportedOutputPath } = require('./applyViteHtmlTransform')
+
 /**
  * The componentAttrStore is the bridge between page + shortcode components
  * and our HTML transform that *renders* those components.
  * - component mount points are ID'd by their index in the DOM for a given page (first, second, etc)
  * - by passing in an id, you'll receive all values necessary to render that mount point (see ComponentAttrs type def)
+ *
+ * @typedef ComponentLookupId
+ * @property {'url' | 'outputPath'} type
+ * @property {string} id
  *
  * @typedef {string} ID
  * @typedef ComponentAttrs
@@ -12,21 +18,23 @@
  * @property {string} children - stringified HTML children
  * @property {string} loader - name of component loader for rendering or hydration
  * @property {boolean} isSSR - whether or not to SSR
- * @property {string} pageOutputPath - the page where this component lives, based on 11ty's inputPath property (ex. src/index.html)
+ * @property {string} pageOutputPath - the page where this component lives, based on 11ty's page.outputPath property (ex. _site/about.html)
+ * @property {string} pageUrl - the output URL where this component is served, based on 11ty's page.url property (ex. /about/)
  * @property {ID} id - a unique identifier for later retrieval from the store
  *
  * @typedef {{
- *  getAllByPage: (pageOutputPath: string) => ComponentAttrs[];
+ *  getAllByPage: (componentLookupId: ComponentLookupId) => ComponentAttrs[];
  *  push: (componentAttrs: ComponentAttrs) => number;
  *  clear: () => void;
  * }} ComponentAttrStore
  * @returns {ComponentAttrStore}
  */
 function toComponentAttrStore() {
-  /**
-   * @type {Record<string, ComponentAttrs[]>}
-   */
-  let componentAttrStore = {}
+  /** @type {Record<string, ComponentAttrs[]>} */
+  let componentAttrStoreByOutputPath = {}
+
+  /** @type {Record<string, ComponentAttrs[]>} */
+  let componentAttrStoreByUrl = {}
 
   /**
    * Add a new item to the store, and receive an index used for later get() calls
@@ -34,22 +42,42 @@ function toComponentAttrStore() {
    * @returns {string} the id of the new componentAttrs entry
    */
   function push(componentAttrs) {
-    const { pageOutputPath } = componentAttrs
-    if (!componentAttrStore[pageOutputPath]) {
-      componentAttrStore[pageOutputPath] = []
+    const { pageOutputPath, pageUrl } = componentAttrs
+    let id = 0
+    if (!isSupportedOutputPath(pageOutputPath) && !pageUrl) {
+      throw Error(
+        '[Slinkity] You are using a component on an unsupported page. Ensure you are only using components on pages with a .html output extension.',
+      )
     }
-    const id = `${componentAttrStore[pageOutputPath].length}`
-    componentAttrStore[pageOutputPath].push({ ...componentAttrs, id })
+    if (isSupportedOutputPath(pageOutputPath)) {
+      if (!componentAttrStoreByOutputPath[pageOutputPath]) {
+        componentAttrStoreByOutputPath[pageOutputPath] = []
+      }
+      id = componentAttrStoreByOutputPath[pageOutputPath].length
+      componentAttrStoreByOutputPath[pageOutputPath].push({ ...componentAttrs, id })
+    }
+    if (pageUrl) {
+      if (!componentAttrStoreByUrl[pageUrl]) {
+        componentAttrStoreByUrl[pageUrl] = []
+      }
+      id = componentAttrStoreByUrl[pageUrl].length
+      componentAttrStoreByUrl[pageUrl].push({ ...componentAttrs, id })
+    }
     return id
   }
 
   /**
    * Get attributes for all components on a given page
-   * @param {string} pageOutputPath - the page where these components live, based on 11ty's outputPath property (ex. _site/index.html)
+   * @param {ComponentLookupId} componentLookupId - either the url or outputPath where this page is served
    * @returns {ComponentAttrs[]} list of attributes for all components on the page
    */
-  function getAllByPage(pageOutputPath) {
-    return componentAttrStore[pageOutputPath] ?? []
+  function getAllByPage(componentLookupId) {
+    if (componentLookupId.type === 'outputPath') {
+      return componentAttrStoreByOutputPath[componentLookupId.id] ?? []
+    } else if (componentLookupId.type === 'url') {
+      return componentAttrStoreByUrl[componentLookupId.id] ?? []
+    }
+    return []
   }
 
   /**
@@ -57,7 +85,8 @@ function toComponentAttrStore() {
    * Should be used to reset between builds
    */
   function clear() {
-    componentAttrStore = {}
+    componentAttrStoreByOutputPath = {}
+    componentAttrStoreByUrl = {}
   }
 
   return {

--- a/packages/slinkity/plugin.js
+++ b/packages/slinkity/plugin.js
@@ -38,7 +38,8 @@ function applyDefaultDirs(dir = {}) {
 // in serverless, 11ty evaluates the plugin *twice* while attaching
 // shortcodes and page extensions *once.* This causes all shortcodes / extensions
 // to reference an old store if we init that store inside the plugin
-const componentAttrStore = toComponentAttrStore()
+/** @type {import('./eleventyConfig/componentAttrStore').ComponentAttrStore} */
+let componentAttrStore = null
 
 // Similar problem with our Vite middleware server.
 // Store as a global to use the same middleware across environments
@@ -67,6 +68,12 @@ module.exports.plugin = function plugin(eleventyConfig, userSlinkityConfig) {
       dir,
       environment,
       userSlinkityConfig,
+    })
+  }
+
+  if (!componentAttrStore) {
+    componentAttrStore = toComponentAttrStore({
+      lookupType: environment === 'development' ? 'url' : 'outputPath',
     })
   }
 
@@ -153,7 +160,7 @@ module.exports.plugin = function plugin(eleventyConfig, userSlinkityConfig) {
       if (serverlessUrl) {
         return await applyViteHtmlTransform({
           content,
-          componentLookupId: { type: 'url', id: serverlessUrl },
+          componentLookupId: serverlessUrl,
           componentAttrStore,
           renderers: userSlinkityConfig.renderers,
           viteSSR,
@@ -198,7 +205,7 @@ module.exports.plugin = function plugin(eleventyConfig, userSlinkityConfig) {
               res.write(
                 await applyViteHtmlTransform({
                   content,
-                  componentLookupId: { type: 'url', id: req.url },
+                  componentLookupId: req.url,
                   componentAttrStore,
                   renderers: userSlinkityConfig.renderers,
                   viteSSR,
@@ -257,7 +264,7 @@ module.exports.plugin = function plugin(eleventyConfig, userSlinkityConfig) {
               res.write(
                 await applyViteHtmlTransform({
                   content,
-                  componentLookupId: { type: 'url', id: req.url },
+                  componentLookupId: req.url,
                   componentAttrStore,
                   renderers: userSlinkityConfig.renderers,
                   viteSSR,
@@ -277,7 +284,7 @@ module.exports.plugin = function plugin(eleventyConfig, userSlinkityConfig) {
     eleventyConfig.addTransform('apply-vite', async function (content, outputPath) {
       return await applyViteHtmlTransform({
         content,
-        componentLookupId: { type: 'outputPath', id: outputPath },
+        componentLookupId: outputPath,
         componentAttrStore,
         renderers: userSlinkityConfig.renderers,
         viteSSR,


### PR DESCRIPTION
**Changes made**
- Hoist `viteSSR` and `componentAttrStore` to the global scope. This prevents lookup mismatches in development (see inline comments on `plugin.js` for more info).
- Updates to `componentAttrStore` keying
  - Add a nested key based on "environment." This corresponds to the deployment directory for a set of routes. Ex. "`_site`" for static builds, `netlify/functions/possum` for serverless functions namespaced to "possum," etc
  - Key based on `url` in development builds. This lets us _remove_ the janky `outputPath` -> `url` regex we used to use, and makes serverless build mapping much simpler!
- Add separate key / value pair for serverless builds based on the `eleventy.serverlessUrlMap` event. This is loosely inspired by the [11ty serverless source code](https://github.com/11ty/eleventy/blob/master/src/Plugins/ServerlessBundlerPlugin.js#L415) since this event is undocumented!