### PR TITLE
Fix: only apply `text/plain` content type to `vite_ping`

### DIFF
--- a/.changeset/proud-moles-refuse.md
+++ b/.changeset/proud-moles-refuse.md
@@ -1,0 +1,5 @@
+---
+"slinkity": patch
+---
+
+Fix: only apply `text/plain` content type to Vite middleware, not user assets

--- a/packages/slinkity/plugin.js
+++ b/packages/slinkity/plugin.js
@@ -142,9 +142,11 @@ module.exports.plugin = function plugin(eleventyConfig, userSlinkityConfig) {
         domdiff: false,
         middleware: [
           (req, res, next) => {
-            // Some Vite server middlewares are missing content types
-            // Set to text/plain as a safe default
-            res.setHeader('Content-Type', 'text/plain')
+            // __vite-ping lacks a content type,
+            // which breaks 11ty's serverless response handler
+            if (req.url.endsWith('__vite_ping')) {
+              res.setHeader('Content-Type', 'text/plain')
+            }
             return viteMiddlewareServer.middlewares(req, res, next)
           },
           async function viteTransformMiddleware(req, res, next) {
@@ -206,10 +208,12 @@ module.exports.plugin = function plugin(eleventyConfig, userSlinkityConfig) {
       eleventyConfig.setBrowserSyncConfig({
         snippet: false,
         middleware: [
-          async (req, res, next) => {
-            // Some Vite server middlewares are missing content types
-            // Set to text/plain as a safe default
-            res.setHeader('Content-Type', 'text/plain')
+          (req, res, next) => {
+            // __vite-ping lacks a content type,
+            // which breaks 11ty's serverless response handler
+            if (req.url.endsWith('__vite_ping')) {
+              res.setHeader('Content-Type', 'text/plain')
+            }
             return viteMiddlewareServer.middlewares(req, res, next)
           },
           async function viteTransformMiddleware(req, res, next) {


### PR DESCRIPTION
## What changed?
Previously we assigned the `text/plain` content type regardless of existing headers. This is very dangerous for non-html assets that rely on correct content types.

Now, we only apply the header override to the `__vite_ping` file. This was the only problematic file when paired with 11ty serverless in my testing