### PR TITLE
fix docs logo wrapping in Webkit

### DIFF
--- a/www/styles/docs.scss
+++ b/www/styles/docs.scss
@@ -75,6 +75,7 @@
   &__home-link:visited {
     color: white;
     text-decoration: none;
+    white-space: nowrap;
     font-weight: bold;
     font-size: 32px;
     margin-inline-end: auto;


### PR DESCRIPTION
Safari 16.1 (18614.2.9.1.12)

macOS Ventura 13.0 (22A380)

Before changes:

<img width="304" alt="image" src="https://user-images.githubusercontent.com/846774/204952339-fecb8977-9873-41f6-9681-28fcf0349e4c.png">

After changes:

<img width="316" alt="image" src="https://user-images.githubusercontent.com/846774/204952578-a1c0b119-9a5c-4345-ae95-be5156dbb5f1.png">
